### PR TITLE
refactor: remove BitArrayType alias and factory functions from public API, update all tests and imports to use explicit BitArray implementations

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = False
 tag = False
 allow_dirty = True

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -42,11 +42,12 @@ jobs:
         id: bump_type
         run: |
           BUMP_TYPE="patch"
-          if echo "${{ github.event.pull_request.labels.*.name }}" | grep -q "major"; then
+          LABELS="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+          if echo "$LABELS" | grep -q "major"; then
             BUMP_TYPE="major"
-          elif echo "${{ github.event.pull_request.labels.*.name }}" | grep -q "minor"; then
+          elif echo "$LABELS" | grep -q "minor"; then
             BUMP_TYPE="minor"
-          elif echo "${{ github.event.pull_request.labels.*.name }}" | grep -q "patch"; then
+          elif echo "$LABELS" | grep -q "patch"; then
             BUMP_TYPE="patch"
           fi
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -19,13 +19,8 @@ Modules:
 from .bitarray import (
     BigIntBitArray,
     BitArray,
-    BitArrayType,
     ListBoolBitArray,
     ListInt64BitArray,
-    create_bitarray,
-    get_available_implementations,
-    parse_bitarray,
-    set_default_implementation,
 )
 from .core import FlexFloat
 
@@ -34,13 +29,8 @@ __author__ = "Ferran Sanchez Llado"
 
 __all__ = [
     "FlexFloat",
-    "BitArrayType",
     "BitArray",
     "ListBoolBitArray",
     "ListInt64BitArray",
     "BigIntBitArray",
-    "create_bitarray",
-    "set_default_implementation",
-    "get_available_implementations",
-    "parse_bitarray",
 ]

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -24,7 +24,7 @@ from .bitarray import (
 )
 from .core import FlexFloat
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __author__ = "Ferran Sanchez Llado"
 
 __all__ = [

--- a/flexfloat/bitarray/__init__.py
+++ b/flexfloat/bitarray/__init__.py
@@ -16,93 +16,11 @@ Example:
 
 from __future__ import annotations
 
-from typing import Dict, Type
-
 from .bitarray import BitArray
 from .bitarray_bigint import BigIntBitArray
 from .bitarray_bool import ListBoolBitArray
 from .bitarray_int64 import ListInt64BitArray
 from .bitarray_mixins import BitArrayCommonMixin
-
-# Type alias for the default BitArray implementation
-BitArrayType: Type[BitArray] = ListBoolBitArray
-
-# Available implementations
-IMPLEMENTATIONS: Dict[str, Type[BitArray]] = {
-    "bool": ListBoolBitArray,
-    "int64": ListInt64BitArray,
-    "bigint": BigIntBitArray,
-}
-
-
-def create_bitarray(
-    implementation: str = "bool", bits: list[bool] | None = None
-) -> BitArray:
-    """Factory function to create a BitArray with the specified implementation.
-
-    Args:
-        implementation (str, optional): The implementation to use ("bool", "int64", or
-            "bigint"). Defaults to "bool".
-        bits (list[bool] | None, optional): Initial list of boolean values. Defaults to
-            None.
-
-    Returns:
-        BitArray: A BitArray instance using the specified implementation.
-
-    Raises:
-        ValueError: If the implementation is not supported.
-    """
-    if implementation not in IMPLEMENTATIONS:
-        raise ValueError(
-            f"Unknown implementation '{implementation}'. "
-            f"Available: {list(IMPLEMENTATIONS.keys())}"
-        )
-
-    return IMPLEMENTATIONS[implementation].from_bits(bits)
-
-
-def set_default_implementation(implementation: str) -> None:
-    """Set the default BitArray implementation.
-
-    Args:
-        implementation (str): The implementation to use as default ("bool", "int64", or
-            "bigint").
-
-    Raises:
-        ValueError: If the implementation is not supported.
-    """
-    global BitArrayType
-
-    if implementation not in IMPLEMENTATIONS:
-        raise ValueError(
-            f"Unknown implementation '{implementation}'. "
-            f"Available: {list(IMPLEMENTATIONS.keys())}"
-        )
-
-    BitArrayType = IMPLEMENTATIONS[implementation]
-
-
-def get_available_implementations() -> list[str]:
-    """Get the list of available BitArray implementations.
-
-    Returns:
-        list[str]: List of available implementation names.
-    """
-    return list(IMPLEMENTATIONS.keys())
-
-
-# Maintain backward compatibility by exposing the methods as module-level functions
-def parse_bitarray(bitstring: str) -> BitArray:
-    """Parse a string of bits (with optional spaces) into a BitArray instance.
-
-    Args:
-        bitstring (str): A string of bits, e.g., "1010 1100".
-
-    Returns:
-        BitArray: A BitArray instance created from the bit string.
-    """
-    return BitArrayType.parse_bitarray(bitstring)
-
 
 __all__ = [
     "BitArray",
@@ -110,8 +28,4 @@ __all__ = [
     "ListInt64BitArray",
     "BigIntBitArray",
     "BitArrayCommonMixin",
-    "create_bitarray",
-    "set_default_implementation",
-    "get_available_implementations",
-    "parse_bitarray",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flexfloat"
-version = "0.1.4"
+version = "0.1.5"
 description = "A library for arbitrary precision floating point arithmetic"
 readme = "README.md"
 authors = [

--- a/tests/test_bigint_bitarray.py
+++ b/tests/test_bigint_bitarray.py
@@ -3,7 +3,7 @@
 import unittest
 from typing import Type
 
-from flexfloat import BigIntBitArray, create_bitarray
+from flexfloat import BigIntBitArray
 from tests import FlexFloatTestCase
 
 
@@ -384,14 +384,6 @@ class TestBigIntBitArray(FlexFloatTestCase):
         empty_ba = self.impl_class.from_bits([])
         with self.assertRaises(AssertionError):
             empty_ba.to_signed_int()
-
-    def test_factory_function_integration(self):
-        """Test integration with the factory function."""
-        bits = [True, False, True, False]
-        ba = create_bitarray("bigint", bits)
-
-        self.assertIsInstance(ba, BigIntBitArray)
-        self.assertEqual(list(ba), bits)
 
     def test_memory_efficiency_indicators(self):
         """Test indicators that the implementation is memory efficient."""

--- a/tests/test_bitarray.py
+++ b/tests/test_bitarray.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from flexfloat import BitArrayType
+from flexfloat import ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -12,21 +12,21 @@ class TestBitArray(FlexFloatTestCase):
     # === BitArray to Integer Conversion Tests ===
     def test_bitarray_to_int_converts_empty_array_to_zero(self):
         """Test that empty bit array converts to zero."""
-        bit_array = BitArrayType.from_bits([])
+        bit_array = ListBoolBitArray.from_bits([])
         expected = 0
         result = bit_array.to_int()
         self.assertEqual(result, expected)
 
     def test_bitarray_to_int_converts_all_false_to_zero(self):
         """Test that all False bits convert to zero."""
-        bit_array = BitArrayType.from_bits([False] * 64)
+        bit_array = ListBoolBitArray.from_bits([False] * 64)
         expected = 0
         result = bit_array.to_int()
         self.assertEqual(result, expected)
 
     def test_bitarray_to_int_converts_single_bit_correctly(self):
         """Test that single True bit converts to 1."""
-        bit_array = BitArrayType.from_bits([True, False])
+        bit_array = ListBoolBitArray.from_bits([True, False])
         expected = 1
         result = bit_array.to_int()
         self.assertEqual(result, expected)
@@ -34,14 +34,14 @@ class TestBitArray(FlexFloatTestCase):
     def test_bitarray_to_int_converts_multiple_bits_correctly(self):
         """Test conversion of multiple bit patterns."""
         # Test binary 101 (decimal 5)
-        bit_array = BitArrayType.from_bits([True, False, True])
+        bit_array = ListBoolBitArray.from_bits([True, False, True])
         expected = 5
         result = bit_array.to_int()
         self.assertEqual(result, expected)
 
     def test_bitarray_to_int_converts_large_number_correctly(self):
         """Test conversion of large bit array to integer."""
-        bit_array = BitArrayType.parse_bitarray(
+        bit_array = ListBoolBitArray.parse_bitarray(
             reversed(
                 "11111111 11111111 11111111 11111111"
                 "11111111 11111111 11111111 11111001"
@@ -53,8 +53,8 @@ class TestBitArray(FlexFloatTestCase):
 
     def test_bitarray_to_int_handles_leading_zeros(self):
         """Test that leading zeros don't affect the result."""
-        bit_array1 = BitArrayType.from_bits([True, False, True])  # 101 = 5
-        bit_array2 = BitArrayType.from_bits(
+        bit_array1 = ListBoolBitArray.from_bits([True, False, True])  # 101 = 5
+        bit_array2 = ListBoolBitArray.from_bits(
             [True, False, True, False, False]  # 00101 = 5
         )
         result1 = bit_array1.to_int()
@@ -64,21 +64,21 @@ class TestBitArray(FlexFloatTestCase):
     # === Signed Integer Conversion Tests ===
     def test_bitarray_to_signed_int_converts_zero_bias_correctly(self):
         """Test signed integer conversion with zero as negative bias."""
-        bitarray = BitArrayType.parse_bitarray("10000000000")  # 11-bit array
+        bitarray = ListBoolBitArray.parse_bitarray("10000000000")  # 11-bit array
         expected = -1023  # -2^(11-1) + 1 = -1024 + 1
         result = bitarray.to_signed_int()
         self.assertEqual(result, expected)
 
     def test_bitarray_to_signed_int_converts_near_zero_correctly(self):
         """Test signed integer conversion near zero."""
-        bitarray = BitArrayType.parse_bitarray("11111111110")  # 11-bit array
+        bitarray = ListBoolBitArray.parse_bitarray("11111111110")  # 11-bit array
         expected = -1  # -2^(11-1) + 1023 = -1024 + 1023
         result = bitarray.to_signed_int()
         self.assertEqual(result, expected)
 
     def test_bitarray_to_signed_int_converts_maximum_value_correctly(self):
         """Test signed integer conversion at maximum value."""
-        bitarray = BitArrayType.parse_bitarray("11111111111")  # 11-bit array
+        bitarray = ListBoolBitArray.parse_bitarray("11111111111")  # 11-bit array
         expected = 1023  # -2^(11-1) + 2047 = -1024 + 2047
         result = bitarray.to_signed_int()
         self.assertEqual(result, expected)
@@ -86,18 +86,18 @@ class TestBitArray(FlexFloatTestCase):
     def test_bitarray_to_signed_int_raises_error_on_empty_array(self):
         """Test that assertion error is raised for empty bit array."""
         with self.assertRaises(AssertionError):
-            BitArrayType.from_bits([]).to_signed_int()
+            ListBoolBitArray.from_bits([]).to_signed_int()
 
     def test_bitarray_to_signed_int_handles_different_lengths(self):
         """Test signed integer conversion with different bit array lengths."""
         # 8-bit test: bias = 2^7 = 128
-        bitarray_8bit = BitArrayType.parse_bitarray("00000001")  # 128 in unsigned
+        bitarray_8bit = ListBoolBitArray.parse_bitarray("00000001")  # 128 in unsigned
         expected_8bit = 0  # 128 - 128 = 0
         result_8bit = bitarray_8bit.to_signed_int()
         self.assertEqual(result_8bit, expected_8bit)
 
         # 4-bit test: bias = 2^3 = 8
-        bitarray_4bit = BitArrayType.parse_bitarray("0011")  # 12 in unsigned
+        bitarray_4bit = ListBoolBitArray.parse_bitarray("0011")  # 12 in unsigned
         expected_4bit = 4  # 12 - 8 = 4
         result_4bit = bitarray_4bit.to_signed_int()
         self.assertEqual(result_4bit, expected_4bit)
@@ -106,27 +106,27 @@ class TestBitArray(FlexFloatTestCase):
         """Test conversion of zero to signed bit array."""
         value = 0
         length = 8
-        result = BitArrayType.from_signed_int(value, length)
+        result = ListBoolBitArray.from_signed_int(value, length)
         # bias = 128, so 0 + 128 = 128
-        expected = BitArrayType.parse_bitarray("00000001")
+        expected = ListBoolBitArray.parse_bitarray("00000001")
         self.assertEqual(result, expected)
 
     def test_signed_int_to_bitarray_converts_positive_value_correctly(self):
         """Test conversion of positive value to signed bit array."""
         value = 5
         length = 8
-        result = BitArrayType.from_signed_int(value, length)
+        result = ListBoolBitArray.from_signed_int(value, length)
 
-        expected = BitArrayType.parse_bitarray("10100001")
+        expected = ListBoolBitArray.parse_bitarray("10100001")
         self.assertEqual(result, expected)
 
     def test_signed_int_to_bitarray_converts_negative_value_correctly(self):
         """Test conversion of negative value to signed bit array."""
         value = -5
         length = 8
-        result = BitArrayType.from_signed_int(value, length)
+        result = ListBoolBitArray.from_signed_int(value, length)
         # bias = 128, so -5 + 128 = 123
-        expected = BitArrayType.parse_bitarray("11011110")
+        expected = ListBoolBitArray.parse_bitarray("11011110")
         self.assertEqual(result, expected)
 
     def test_signed_int_to_bitarray_raises_error_on_overflow(self):
@@ -136,23 +136,23 @@ class TestBitArray(FlexFloatTestCase):
 
         # Test values within range should work
         try:
-            BitArrayType.from_signed_int(127, 8)
-            BitArrayType.from_signed_int(-128, 8)
+            ListBoolBitArray.from_signed_int(127, 8)
+            ListBoolBitArray.from_signed_int(-128, 8)
         except AssertionError:
             self.fail("Valid values should not raise AssertionError")
 
         # Test values that should definitely fail
         with self.assertRaises(AssertionError):
-            BitArrayType.from_signed_int(256, 8)  # Beyond max range
+            ListBoolBitArray.from_signed_int(256, 8)  # Beyond max range
         with self.assertRaises(AssertionError):
-            BitArrayType.from_signed_int(-129, 8)  # Beyond min range
+            ListBoolBitArray.from_signed_int(-129, 8)  # Beyond min range
 
     def test_signed_int_to_bitarray_roundtrip_preserves_value(self):
         """Test that signed int->bitarray->signed int preserves the original value."""
         length = 8
         test_values = [0, 1, -1, 127, -128, 50, -75]
         for value in test_values:
-            bit_array = BitArrayType.from_signed_int(value, length)
+            bit_array = ListBoolBitArray.from_signed_int(value, length)
             result = bit_array.to_signed_int()
             self.assertEqual(result, value, f"Roundtrip failed for {value}")
 
@@ -160,55 +160,55 @@ class TestBitArray(FlexFloatTestCase):
     def test_shift_bitarray_no_shift_returns_original(self):
         """Test that zero shift returns the original array."""
         bit_array = [True, False, True, False]
-        result = BitArrayType.from_bits(bit_array).shift(0)
-        self.assertEqual(result, BitArrayType.from_bits(bit_array))
+        result = ListBoolBitArray.from_bits(bit_array).shift(0)
+        self.assertEqual(result, ListBoolBitArray.from_bits(bit_array))
 
     def test_shift_bitarray_left_shift_with_default_fill(self):
         """Test left shift with default False fill."""
         bit_array = [True, False, True, False]
-        result = BitArrayType.from_bits(bit_array).shift(-2)
-        expected = BitArrayType.from_bits([False, False, True, False])
+        result = ListBoolBitArray.from_bits(bit_array).shift(-2)
+        expected = ListBoolBitArray.from_bits([False, False, True, False])
         self.assertEqual(result, expected)
 
     def test_shift_bitarray_left_shift_with_true_fill(self):
         """Test left shift with True fill value."""
         bit_array = [True, False, True, False]
-        result = BitArrayType.from_bits(bit_array).shift(-2, fill=True)
-        expected = BitArrayType.from_bits([True, True, True, False])
+        result = ListBoolBitArray.from_bits(bit_array).shift(-2, fill=True)
+        expected = ListBoolBitArray.from_bits([True, True, True, False])
         self.assertEqual(result, expected)
 
     def test_shift_bitarray_right_shift_with_default_fill(self):
         """Test right shift with default False fill."""
         bit_array = [True, False, True, False]
-        result = BitArrayType.from_bits(bit_array).shift(2)
-        expected = BitArrayType.from_bits([True, False, False, False])
+        result = ListBoolBitArray.from_bits(bit_array).shift(2)
+        expected = ListBoolBitArray.from_bits([True, False, False, False])
         self.assertEqual(result, expected)
 
     def test_shift_bitarray_right_shift_with_true_fill(self):
         """Test right shift with True fill value."""
         bit_array = [True, False, True, False]
-        result = BitArrayType.from_bits(bit_array).shift(2, fill=True)
-        expected = BitArrayType.from_bits([True, False, True, True])
+        result = ListBoolBitArray.from_bits(bit_array).shift(2, fill=True)
+        expected = ListBoolBitArray.from_bits([True, False, True, True])
         self.assertEqual(result, expected)
 
     def test_shift_bitarray_shift_entire_length(self):
         """Test shifting by the entire length of the array."""
         bit_array = [True, False, True, False]
         # Left shift by entire length
-        result_left = BitArrayType.from_bits(bit_array).shift(-4)
-        expected_left = BitArrayType.from_bits([False, False, False, False])
+        result_left = ListBoolBitArray.from_bits(bit_array).shift(-4)
+        expected_left = ListBoolBitArray.from_bits([False, False, False, False])
         self.assertEqual(result_left, expected_left)
 
         # Right shift by entire length
-        result_right = BitArrayType.from_bits(bit_array).shift(4)
-        expected_right = BitArrayType.from_bits([False, False, False, False])
+        result_right = ListBoolBitArray.from_bits(bit_array).shift(4)
+        expected_right = ListBoolBitArray.from_bits([False, False, False, False])
         self.assertEqual(result_right, expected_right)
 
     def test_shift_bitarray_shift_beyond_length(self):
         """Test shifting beyond the array length."""
         bit_array = [True, False, True, False]
-        result = BitArrayType.from_bits(bit_array).shift(-5)
-        expected = BitArrayType.from_bits([False] * len(bit_array))
+        result = ListBoolBitArray.from_bits(bit_array).shift(-5)
+        expected = ListBoolBitArray.from_bits([False] * len(bit_array))
         self.assertEqual(result, expected)
 
     def test_shift_bitarray_preserves_array_length(self):
@@ -216,7 +216,7 @@ class TestBitArray(FlexFloatTestCase):
         bit_array = [True, False, True, False, True]
         shifts = [0, 1, -1, 3, -3]
         for shift in shifts:
-            result = BitArrayType.from_bits(bit_array).shift(shift)
+            result = ListBoolBitArray.from_bits(bit_array).shift(shift)
             # For shifts within reasonable bounds, length should be preserved
             if abs(shift) <= len(bit_array):
                 self.assertEqual(
@@ -228,7 +228,7 @@ class TestBitArray(FlexFloatTestCase):
     # === BitArray Class Method Tests ===
     def test_bitarray_shift_method_works_correctly(self):
         """Test that BitArray.shift method works correctly."""
-        bit_array = BitArrayType.from_bits([True, False, True, False])
+        bit_array = ListBoolBitArray.from_bits([True, False, True, False])
 
         # Test no shift
         result = bit_array.shift(0)
@@ -236,35 +236,35 @@ class TestBitArray(FlexFloatTestCase):
 
         # Test left shift
         result = bit_array.shift(-2)
-        expected = BitArrayType.from_bits([False, False, True, False])
+        expected = ListBoolBitArray.from_bits([False, False, True, False])
         self.assertEqual(result, expected)
 
         # Test right shift
         result = bit_array.shift(2)
-        expected = BitArrayType.from_bits([True, False, False, False])
+        expected = ListBoolBitArray.from_bits([True, False, False, False])
         self.assertEqual(result, expected)
 
     def test_bitarray_from_signed_int_class_method(self):
         """Test BitArray.from_signed_int class method."""
         value = 5
         length = 8
-        result = BitArrayType.from_signed_int(value, length)
-        expected = BitArrayType.parse_bitarray("10100001")
+        result = ListBoolBitArray.from_signed_int(value, length)
+        expected = ListBoolBitArray.parse_bitarray("10100001")
         self.assertEqual(result, expected)
 
     def test_bitarray_factory_methods(self):
         """Test BitArray factory methods."""
         # Test zeros
-        zeros = BitArrayType.zeros(5)
-        self.assertEqual(zeros, BitArrayType.from_bits([False] * 5))
+        zeros = ListBoolBitArray.zeros(5)
+        self.assertEqual(zeros, ListBoolBitArray.from_bits([False] * 5))
 
         # Test ones
-        ones = BitArrayType.ones(5)
-        self.assertEqual(ones, BitArrayType.from_bits([True] * 5))
+        ones = ListBoolBitArray.ones(5)
+        self.assertEqual(ones, ListBoolBitArray.from_bits([True] * 5))
 
     def test_bitarray_utility_methods(self):
         """Test BitArray utility methods."""
-        bit_array = BitArrayType.from_bits([True, False, True, True, False])
+        bit_array = ListBoolBitArray.from_bits([True, False, True, True, False])
 
         # Test any
         self.assertTrue(bit_array.any())

--- a/tests/test_bitarray_implementations.py
+++ b/tests/test_bitarray_implementations.py
@@ -8,8 +8,6 @@ from flexfloat import (
     BitArray,
     ListBoolBitArray,
     ListInt64BitArray,
-    create_bitarray,
-    get_available_implementations,
 )
 from tests import FlexFloatTestCase
 
@@ -25,27 +23,14 @@ class TestBitArrayImplementations(FlexFloatTestCase):
             ("bigint", BigIntBitArray),
         ]
 
-    def test_factory_function(self):
+    def test_from_bits_function(self):
         """Test the factory function creates correct implementations."""
         for impl_name, impl_class in self.get_implementations():
             with self.subTest(implementation=impl_name):
                 bits = [True, False, True]
-                result = create_bitarray(impl_name, bits)
+                result = impl_class.from_bits(bits)
                 self.assertIsInstance(result, impl_class)
                 self.assertEqual(list(result), bits)
-
-    def test_factory_function_invalid_implementation(self):
-        """Test factory function raises error for invalid implementation."""
-        with self.assertRaises(ValueError):
-            create_bitarray("invalid_implementation")
-
-    def test_get_available_implementations(self):
-        """Test getting available implementations."""
-        implementations = get_available_implementations()
-        self.assertIsInstance(implementations, list)
-        self.assertIn("bool", implementations)
-        self.assertIn("int64", implementations)
-        self.assertIn("bigint", implementations)
 
     def test_empty_initialization(self):
         """Test that all implementations handle empty initialization consistently."""

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -3,7 +3,7 @@
 import math
 import unittest
 
-from flexfloat import BitArrayType
+from flexfloat import ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -16,31 +16,31 @@ class TestConversions(FlexFloatTestCase):
         """Test that zero is converted to all False bits."""
         value = 0
         expected = [False] * 64
-        result = BitArrayType.from_float(value)
-        self.assertEqual(result, BitArrayType.from_bits(expected))
+        result = ListBoolBitArray.from_float(value)
+        self.assertEqual(result, ListBoolBitArray.from_bits(expected))
 
     def test_float_to_bitarray_converts_positive_one_correctly(self):
         """Test that 1.0 is converted to correct IEEE 754 representation."""
         value = 1.0
-        expected = BitArrayType.parse_bitarray(
+        expected = ListBoolBitArray.parse_bitarray(
             "00000000 00000000 00000000 00000000 00000000 00000000 00001111 11111100"
         )
-        result = BitArrayType.from_float(value)
+        result = ListBoolBitArray.from_float(value)
         self.assertEqual(result, expected)
 
     def test_float_to_bitarray_converts_negative_integer_correctly(self):
         """Test that large negative integer is converted correctly."""
         value = -15789123456789
-        expected = BitArrayType.parse_bitarray(
+        expected = ListBoolBitArray.parse_bitarray(
             "00000000 01010100 01111001 00001100 01000110 00011101 00110101 01000011"
         )
-        result = BitArrayType.from_float(value)
+        result = ListBoolBitArray.from_float(value)
         self.assertEqual(result, expected)
 
     def test_float_to_bitarray_converts_fractional_number(self):
         """Test conversion of fractional numbers."""
         value = 0.5
-        result = BitArrayType.from_float(value)
+        result = ListBoolBitArray.from_float(value)
         # 0.5 in IEEE 754: sign=0, exponent=01111111110, mantissa=0...0
         self.assertFalse(result[0])  # Sign bit should be False (positive)
         self.assertEqual(len(result), 64)
@@ -48,7 +48,7 @@ class TestConversions(FlexFloatTestCase):
     def test_float_to_bitarray_converts_infinity(self):
         """Test conversion of positive infinity."""
         value = float("inf")
-        result = BitArrayType.from_float(value)
+        result = ListBoolBitArray.from_float(value)
         # Infinity has all exponent bits set to 1 and mantissa all 0
         self.assertFalse(result[63])  # Sign bit False for positive infinity
         # Exponent bits (52-62) should all be True
@@ -59,7 +59,7 @@ class TestConversions(FlexFloatTestCase):
     def test_float_to_bitarray_converts_negative_infinity(self):
         """Test conversion of negative infinity."""
         value = float("-inf")
-        result = BitArrayType.from_float(value)
+        result = ListBoolBitArray.from_float(value)
         self.assertTrue(result[63])  # Sign bit True for negative infinity
         self.assertTrue(all(result[52:63]))  # All exponent bits True
         self.assertFalse(any(result[0:52]))  # All mantissa bits False
@@ -67,7 +67,7 @@ class TestConversions(FlexFloatTestCase):
     def test_float_to_bitarray_converts_nan(self):
         """Test conversion of NaN (Not a Number)."""
         value = float("nan")
-        result = BitArrayType.from_float(value)
+        result = ListBoolBitArray.from_float(value)
         # NaN has all exponent bits set to 1 and at least one mantissa bit set
         self.assertTrue(all(result[52:63]))  # All exponent bits True
         self.assertTrue(any(result[0:52]))  # At least one mantissa bit True
@@ -77,12 +77,12 @@ class TestConversions(FlexFloatTestCase):
         """Test that all False bits convert to zero."""
         bit_array = [False] * 64
         expected = 0.0
-        result = BitArrayType.from_bits(bit_array).to_float()
+        result = ListBoolBitArray.from_bits(bit_array).to_float()
         self.assertEqual(result, expected)
 
     def test_bitarray_to_float_converts_positive_one_correctly(self):
         """Test that IEEE 754 representation of 1.0 converts correctly."""
-        bit_array = BitArrayType.parse_bitarray(
+        bit_array = ListBoolBitArray.parse_bitarray(
             "00000000 00000000 00000000 00000000 00000000 00000000 00001111 11111100"
         )
         expected = 1.0
@@ -91,7 +91,7 @@ class TestConversions(FlexFloatTestCase):
 
     def test_bitarray_to_float_converts_negative_number_correctly(self):
         """Test that negative number bit array converts correctly."""
-        bit_array = BitArrayType.parse_bitarray(
+        bit_array = ListBoolBitArray.parse_bitarray(
             "00000000 01010100 01111001 00001100 01000110 00011101 00110101 01000011"
         )
         expected = -15789123456789.0
@@ -101,16 +101,16 @@ class TestConversions(FlexFloatTestCase):
     def test_bitarray_to_float_raises_error_on_wrong_length(self):
         """Test that assertion error is raised for non-64-bit arrays."""
         with self.assertRaises(AssertionError):
-            BitArrayType.from_bits([True] * 32).to_float()  # Wrong length
+            ListBoolBitArray.from_bits([True] * 32).to_float()  # Wrong length
         with self.assertRaises(AssertionError):
-            BitArrayType.from_bits().to_float()  # Empty array
+            ListBoolBitArray.from_bits().to_float()  # Empty array
 
     def test_bitarray_to_float_roundtrip_preserves_value(self):
         """Test that converting float->bitarray->float preserves the original value."""
         original_values = [0.0, 1.0, -1.0, 3.14159, -2.71828, 1e100, 1e-100]
         for value in original_values:
             if not (math.isnan(value) or math.isinf(value)):
-                bit_array = BitArrayType.from_float(value)
+                bit_array = ListBoolBitArray.from_float(value)
                 result = bit_array.to_float()
                 self.assertEqual(result, value, f"Roundtrip failed for {value}")
 

--- a/tests/test_flexfloat.py
+++ b/tests/test_flexfloat.py
@@ -3,7 +3,7 @@
 import sys
 import unittest
 
-from flexfloat import BitArrayType, FlexFloat
+from flexfloat import FlexFloat, ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -21,8 +21,8 @@ class TestFlexFloat(FlexFloatTestCase):
     def test_flexfloat_constructor_with_custom_values(self):
         """Test FlexFloat constructor with custom sign, exponent, and fraction."""
         sign = True
-        exponent = BitArrayType.from_bits([True, False] * 5 + [True])  # 11 bits
-        fraction = BitArrayType.from_bits([False, True] * 26)  # 52 bits
+        exponent = ListBoolBitArray.from_bits([True, False] * 5 + [True])  # 11 bits
+        fraction = ListBoolBitArray.from_bits([False, True] * 26)  # 52 bits
         bf = FlexFloat(sign=sign, exponent=exponent, fraction=fraction)
         self.assertEqual(bf.sign, sign)
         self.assertEqual(bf.exponent, exponent)
@@ -57,8 +57,8 @@ class TestFlexFloat(FlexFloatTestCase):
         """Test that to_float handles extended precision by truncating/padding."""
         # Shorter exponent length
         bf_short_exp = FlexFloat(
-            exponent=BitArrayType.from_bits([False] * 10),
-            fraction=BitArrayType.from_bits([False] * 52),
+            exponent=ListBoolBitArray.from_bits([False] * 10),
+            fraction=ListBoolBitArray.from_bits([False] * 52),
         )
         # Will raise error as it does not meet the standard 64-bit FlexFloat
         with self.assertRaises(ValueError):
@@ -66,16 +66,16 @@ class TestFlexFloat(FlexFloatTestCase):
 
         # Shorter fraction length
         bf_short_frac = FlexFloat(
-            exponent=BitArrayType.from_bits([False] * 11),
-            fraction=BitArrayType.from_bits([False] * 51),
+            exponent=ListBoolBitArray.from_bits([False] * 11),
+            fraction=ListBoolBitArray.from_bits([False] * 51),
         )
         with self.assertRaises(ValueError):
             bf_short_frac.to_float()
 
         # Extended exponent length (should be truncated)
         bf_long_exp = FlexFloat(
-            exponent=BitArrayType.from_bits([False] * 15),
-            fraction=BitArrayType.from_bits([False] * 52),
+            exponent=ListBoolBitArray.from_bits([False] * 15),
+            fraction=ListBoolBitArray.from_bits([False] * 52),
         )
         result = bf_long_exp.to_float()
         self.assertIsInstance(result, float)

--- a/tests/test_multiplication.py
+++ b/tests/test_multiplication.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from flexfloat import BitArrayType, FlexFloat
+from flexfloat import FlexFloat, ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -237,8 +237,8 @@ class TestMultiplication(FlexFloatTestCase):
     def test_flexfloat_multiplication_extreme_exponent_ranges(self):
         large_exp = FlexFloat(
             sign=False,
-            exponent=BitArrayType.from_signed_int(2046, 12),
-            fraction=BitArrayType.from_signed_int(1, 52)[:52],
+            exponent=ListBoolBitArray.from_signed_int(2046, 12),
+            fraction=ListBoolBitArray.from_signed_int(1, 52),
         )
         multiplier = FlexFloat.from_float(8.0)
         result = large_exp * multiplier

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -3,7 +3,7 @@
 import math
 import unittest
 
-from flexfloat import BitArrayType, FlexFloat
+from flexfloat import FlexFloat, ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -247,7 +247,7 @@ class TestPower(FlexFloatTestCase):
         """Test that power operations reject non-FlexFloat operands."""
         bf = FlexFloat.from_float(2.0)
         with self.assertRaises(TypeError):
-            bf ** "not a number"
+            bf ** "not a number"  # type: ignore
 
     def test_flexfloat_power_with_mixed_operand_types(self):
         """Test power operations with mixed operand types."""
@@ -361,9 +361,9 @@ class TestPower(FlexFloatTestCase):
     def test_flexfloat_power_extreme_exponent_ranges(self):
         """Test power operations with extreme exponent ranges."""
         # Create FlexFloat with large exponent
-        large_exp = BitArrayType.from_signed_int(1000, 15)
+        large_exp = ListBoolBitArray.from_signed_int(1000, 15)
         base = FlexFloat(
-            sign=False, exponent=large_exp, fraction=BitArrayType.zeros(52)
+            sign=False, exponent=large_exp, fraction=ListBoolBitArray.zeros(52)
         )
         exponent = FlexFloat.from_float(2000.0)
         result = base**exponent

--- a/tests/test_str_representation.py
+++ b/tests/test_str_representation.py
@@ -3,7 +3,7 @@
 import math
 import unittest
 
-from flexfloat import BitArrayType, FlexFloat
+from flexfloat import FlexFloat, ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -230,15 +230,15 @@ class TestStrRepresentation(FlexFloatTestCase):
     def test_str_extended_exponent_numbers(self):
         """Test string representation of numbers with extended exponents."""
         # Test with large exponent
-        extended_exp = BitArrayType.from_signed_int(500, 12)  # 12-bit exponent
-        frac = BitArrayType.zeros(52)
+        extended_exp = ListBoolBitArray.from_signed_int(500, 12)  # 12-bit exponent
+        frac = ListBoolBitArray.zeros(52)
         ff = FlexFloat(sign=False, exponent=extended_exp, fraction=frac)
         result = str(ff)
         # This represents 2^501, which in decimal scientific notation is ~6.54678e+150
         self.assertEqual(result, "6.54678e+150")
 
         # Test with negative large exponent
-        extended_exp = BitArrayType.from_signed_int(-500, 12)  # 12-bit exponent
+        extended_exp = ListBoolBitArray.from_signed_int(-500, 12)  # 12-bit exponent
         ff = FlexFloat(sign=False, exponent=extended_exp, fraction=frac)
         result = str(ff)
         # This represents 2^(-499), which in decimal scientific notation is 6.10987e-151
@@ -252,8 +252,8 @@ class TestStrRepresentation(FlexFloatTestCase):
     def test_str_extreme_exponent_numbers(self):
         """Test string representation of numbers with extreme exponents."""
         # Test with very large exponent that causes overflow
-        extended_exp = BitArrayType.from_signed_int(2000, 15)  # 15-bit exponent
-        frac = BitArrayType.zeros(52)
+        extended_exp = ListBoolBitArray.from_signed_int(2000, 15)  # 15-bit exponent
+        frac = ListBoolBitArray.zeros(52)
         ff = FlexFloat(sign=False, exponent=extended_exp, fraction=frac)
         result = str(ff)
         # This represents 2^2001, which in decimal scientific notation is ~2.29626e+602

--- a/tests/test_subtraction.py
+++ b/tests/test_subtraction.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from flexfloat import BitArrayType, FlexFloat
+from flexfloat import FlexFloat, ListBoolBitArray
 from tests import FlexFloatTestCase
 
 
@@ -80,7 +80,7 @@ class TestSubtraction(FlexFloatTestCase):
     def test_flexfloat_subtraction_rejects_non_flexfloat_operands(self):
         bf = FlexFloat.from_float(1.0)
         with self.assertRaises(TypeError):
-            bf - "not a number"
+            bf - "not a number"  # type: ignore
 
     def test_flexfloat_subtraction_handles_nan_operands(self):
         bf_normal = FlexFloat.from_float(1.0)
@@ -209,17 +209,17 @@ class TestSubtraction(FlexFloatTestCase):
         # Create a FlexFloat with a very small exponent near the limit
         small_exp_bf = FlexFloat(
             sign=False,
-            exponent=BitArrayType.from_signed_int(
+            exponent=ListBoolBitArray.from_signed_int(
                 -1022, 11
             ),  # Near minimum for double precision
-            fraction=BitArrayType.from_signed_int(1, 52)[:52],
+            fraction=ListBoolBitArray.from_signed_int(1, 52)[:52],
         )
 
         # Create another very close number
         slightly_larger = FlexFloat(
             sign=False,
-            exponent=BitArrayType.from_signed_int(-1022, 11),
-            fraction=BitArrayType.from_signed_int(2, 52)[:52],
+            exponent=ListBoolBitArray.from_signed_int(-1022, 11),
+            fraction=ListBoolBitArray.from_signed_int(2, 52)[:52],
         )
 
         result3 = slightly_larger - small_exp_bf


### PR DESCRIPTION
- Removed `BitArrayType`, `create_bitarray`, `set_default_implementation`, `get_available_implementations`, and `parse_bitarray` from the public API in flexfloat and `flexfloat.bitarray`.
- Updated all test files to use explicit BitArray implementations (e.g., `ListBoolBitArray`, `BigIntBitArray`) instead of the removed factory functions and type aliases.
- Cleaned up imports and test logic to directly reference the desired BitArray class.
- This is a breaking change: users must now explicitly select the BitArray implementation rather than relying on the previous factory pattern.