### PR TITLE
feat: add flexfloat.math module and comprehensive math function tests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = False
 tag = False
 allow_dirty = True

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -25,7 +25,7 @@ from .bitarray import (
 )
 from .core import FlexFloat
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Ferran Sanchez Llado"
 
 __all__ = [

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -16,6 +16,7 @@ Modules:
     types: Type definitions
 """
 
+from . import math
 from .bitarray import (
     BigIntBitArray,
     BitArray,
@@ -23,7 +24,6 @@ from .bitarray import (
     ListInt64BitArray,
 )
 from .core import FlexFloat
-from . import math
 
 __version__ = "0.3.0"
 __author__ = "Ferran Sanchez Llado"

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -23,6 +23,7 @@ from .bitarray import (
     ListInt64BitArray,
 )
 from .core import FlexFloat
+from . import math
 
 __version__ = "0.3.0"
 __author__ = "Ferran Sanchez Llado"
@@ -33,4 +34,5 @@ __all__ = [
     "ListBoolBitArray",
     "ListInt64BitArray",
     "BigIntBitArray",
+    "math",
 ]

--- a/flexfloat/core.py
+++ b/flexfloat/core.py
@@ -42,8 +42,6 @@ class FlexFloat:
             (mantissa) of the number.
     """
 
-    e: ClassVar[FlexFloat]
-    """The mathematical constant e as a FlexFloat instance."""
     _bitarray_implementation: ClassVar[Type[BitArray]] = ListBoolBitArray
     """The BitArray implementation class used for all FlexFloat instances."""
 
@@ -851,16 +849,6 @@ class FlexFloat:
         """
         return abs(self)
 
-    def exp(self) -> FlexFloat:
-        """Calculates the exponential of the FlexFloat instance.
-
-        Returns:
-            FlexFloat: A new FlexFloat instance representing e raised to the power of
-                this instance.
-        """
-        # Use Python's math.exp for the base calculation
-        return FlexFloat.e**self
-
     def __pow__(self, other: FlexFloat | Number) -> FlexFloat:
         """Raises this FlexFloat to the power of another FlexFloat or number.
 
@@ -1110,7 +1098,3 @@ class FlexFloat:
             FlexFloat: A new FlexFloat instance representing the power.
         """
         return FlexFloat.from_float(base) ** self
-
-
-# Initialize class variable after class definition
-FlexFloat.e = FlexFloat.from_float(math.e)

--- a/flexfloat/math.py
+++ b/flexfloat/math.py
@@ -1,0 +1,268 @@
+"""Math module for FlexFloat, similar to Python's math module.
+
+Provides mathematical functions that operate on FlexFloat instances.
+"""
+
+import math
+from typing import Final, Iterable
+from .core import FlexFloat
+
+# Constants
+e: Final[FlexFloat] = FlexFloat.from_float(math.e)
+pi: Final[FlexFloat] = FlexFloat.from_float(math.pi)
+inf: Final[FlexFloat] = FlexFloat.infinity()
+nan: Final[FlexFloat] = FlexFloat.nan()
+tau: Final[FlexFloat] = FlexFloat.from_float(math.tau)
+
+_0_5: Final[FlexFloat] = FlexFloat.from_float(0.5)
+
+
+# Math-like functions for FlexFloat
+def exp(x: FlexFloat) -> FlexFloat:
+    """Return e raised to the power of x (where x is a FlexFloat)."""
+    return e**x
+
+
+def pow(base: FlexFloat, exp: FlexFloat) -> FlexFloat:
+    """Return base raised to the power of exp (both are FlexFloat instances)."""
+    return base**exp
+
+
+def copysign(x: FlexFloat, y: FlexFloat) -> FlexFloat:
+    """Return a FlexFloat with the magnitude of x and the sign of y."""
+    result = x.copy()
+    result.sign = y.sign
+    return result
+
+
+def fabs(x: FlexFloat) -> FlexFloat:
+    """Return the absolute value of x."""
+    return abs(x)
+
+
+def isinf(x: FlexFloat) -> bool:
+    """Check if x is positive or negative infinity."""
+    return x.is_infinity()
+
+
+def isnan(x: FlexFloat) -> bool:
+    """Check if x is NaN (not a number)."""
+    return x.is_nan()
+
+
+def isfinite(x: FlexFloat) -> bool:
+    """Check if x is neither an infinity nor NaN."""
+    return not x.is_infinity() and not x.is_nan()
+
+
+def sqrt(x: FlexFloat) -> FlexFloat:
+    """Return the square root of x (using power operator)."""
+    return x**_0_5
+
+
+# Unimplemented functions
+def acos(x: FlexFloat) -> FlexFloat:
+    """Return the arc cosine of x (not implemented)."""
+    raise NotImplementedError("acos is not implemented for FlexFloat.")
+
+
+def acosh(x: FlexFloat) -> FlexFloat:
+    """Return the hyperbolic arc cosine of x (not implemented)."""
+    raise NotImplementedError("acosh is not implemented for FlexFloat.")
+
+
+def asin(x: FlexFloat) -> FlexFloat:
+    """Return the arc sine of x (not implemented)."""
+    raise NotImplementedError("asin is not implemented for FlexFloat.")
+
+
+def asinh(x: FlexFloat) -> FlexFloat:
+    """Return the hyperbolic arc sine of x (not implemented)."""
+    raise NotImplementedError("asinh is not implemented for FlexFloat.")
+
+
+def atan(x: FlexFloat) -> FlexFloat:
+    """Return the arc tangent of x (not implemented)."""
+    raise NotImplementedError("atan is not implemented for FlexFloat.")
+
+
+def atan2(y: FlexFloat, x: FlexFloat) -> FlexFloat:
+    """Return the arc tangent of y/x (not implemented)."""
+    raise NotImplementedError("atan2 is not implemented for FlexFloat.")
+
+
+def atanh(x: FlexFloat) -> FlexFloat:
+    """Return the hyperbolic arc tangent of x (not implemented)."""
+    raise NotImplementedError("atanh is not implemented for FlexFloat.")
+
+
+def cbrt(x: FlexFloat) -> FlexFloat:
+    """Return the cube root of x (not implemented)."""
+    raise NotImplementedError("cbrt is not implemented for FlexFloat.")
+
+
+def ceil(x: FlexFloat) -> FlexFloat:
+    """Return the ceiling of x (not implemented)."""
+    raise NotImplementedError("ceil is not implemented for FlexFloat.")
+
+
+# Not implemented functions
+def dist(p: Iterable[FlexFloat], q: Iterable[FlexFloat]) -> FlexFloat:
+    """Return the Euclidean distance between two points p and q (not implemented)."""
+    raise NotImplementedError("dist is not implemented for FlexFloat.")
+
+
+def erf(x: FlexFloat) -> FlexFloat:
+    """Return the error function of x (not implemented)."""
+    raise NotImplementedError("erf is not implemented for FlexFloat.")
+
+
+def erfc(x: FlexFloat) -> FlexFloat:
+    """Return the complementary error function of x (not implemented)."""
+    raise NotImplementedError("erfc is not implemented for FlexFloat.")
+
+
+def expm1(x: FlexFloat) -> FlexFloat:
+    """Return e raised to the power of x, minus 1 (not implemented)."""
+    raise NotImplementedError("expm1 is not implemented for FlexFloat.")
+
+
+def factorial(x: FlexFloat) -> FlexFloat:
+    """Return the factorial of x (not implemented)."""
+    raise NotImplementedError("factorial is not implemented for FlexFloat.")
+
+
+def fmod(x: FlexFloat, y: FlexFloat) -> FlexFloat:
+    """Return the remainder of x divided by y (not implemented)."""
+    raise NotImplementedError("fmod is not implemented for FlexFloat.")
+
+
+def frexp(x: FlexFloat) -> tuple[FlexFloat, int]:
+    """Return the mantissa and exponent of x (not implemented)."""
+    raise NotImplementedError("frexp is not implemented for FlexFloat.")
+
+
+def fsum(seq: Iterable[FlexFloat]) -> FlexFloat:
+    """Return an accurate floating-point sum of the values in seq (not implemented)."""
+    raise NotImplementedError("fsum is not implemented for FlexFloat.")
+
+
+def gamma(x: FlexFloat) -> FlexFloat:
+    """Return the gamma function of x (not implemented)."""
+    raise NotImplementedError("gamma is not implemented for FlexFloat.")
+
+
+def gcd(*integers: FlexFloat) -> FlexFloat:
+    """Return the greatest common divisor of the integers (not implemented)."""
+    raise NotImplementedError("gcd is not implemented for FlexFloat.")
+
+
+def hypot(*coordinates: FlexFloat) -> FlexFloat:
+    """Return the Euclidean norm, sqrt(x1*x1 + x2*x2 + ... + xn*xn) (not implemented)."""
+    raise NotImplementedError("hypot is not implemented for FlexFloat.")
+
+
+def isclose(
+    a: FlexFloat,
+    b: FlexFloat,
+    *,
+    rel_tol: FlexFloat = FlexFloat.from_float(1e-09),
+    abs_tol: FlexFloat = FlexFloat.from_float(0.0),
+) -> bool:
+    """Check if two FlexFloat instances are close in value (not implemented)."""
+    raise NotImplementedError("isclose is not implemented for FlexFloat.")
+
+
+def lcm(*integers: FlexFloat) -> FlexFloat:
+    """Return the least common multiple of the integers (not implemented)."""
+    raise NotImplementedError("lcm is not implemented for FlexFloat.")
+
+
+def ldexp(x: FlexFloat, i: int) -> FlexFloat:
+    """Return x * (2**i) (not implemented)."""
+    raise NotImplementedError("ldexp is not implemented for FlexFloat.")
+
+
+def lgamma(x: FlexFloat) -> FlexFloat:
+    """Return the natural logarithm of the absolute value of the gamma function of x (not implemented)."""
+    raise NotImplementedError("lgamma is not implemented for FlexFloat.")
+
+
+def log(x: FlexFloat, base: FlexFloat = e) -> FlexFloat:
+    """Return the logarithm of x to the given base (not implemented)."""
+    raise NotImplementedError("log is not implemented for FlexFloat.")
+
+
+def log10(x: FlexFloat) -> FlexFloat:
+    """Return the base-10 logarithm of x (not implemented)."""
+    raise NotImplementedError("log10 is not implemented for FlexFloat.")
+
+
+def log1p(x: FlexFloat) -> FlexFloat:
+    """Return the natural logarithm of 1 + x (not implemented)."""
+    raise NotImplementedError("log1p is not implemented for FlexFloat.")
+
+
+def log2(x: FlexFloat) -> FlexFloat:
+    """Return the base-2 logarithm of x (not implemented)."""
+    raise NotImplementedError("log2 is not implemented for FlexFloat.")
+
+
+def modf(x: FlexFloat) -> tuple[FlexFloat, FlexFloat]:
+    """Return the fractional and integer parts of x (not implemented)."""
+    raise NotImplementedError("modf is not implemented for FlexFloat.")
+
+
+def nextafter(x: FlexFloat, y: FlexFloat, *, steps: int | None = None) -> FlexFloat:
+    """Return the next representable FlexFloat value after x towards y (not implemented)."""
+    raise NotImplementedError("nextafter is not implemented for FlexFloat.")
+
+
+def perm(n: FlexFloat, k: FlexFloat | None = None) -> FlexFloat:
+    """Return the number of ways to choose k items from n items without repetition (not implemented)."""
+    raise NotImplementedError("perm is not implemented for FlexFloat.")
+
+
+def radians(x: FlexFloat) -> FlexFloat:
+    """Convert angle x from degrees to radians (not implemented)."""
+    raise NotImplementedError("radians is not implemented for FlexFloat.")
+
+
+def remainder(x: FlexFloat, y: FlexFloat) -> FlexFloat:
+    """Return the remainder of x divided by y (not implemented)."""
+    raise NotImplementedError("remainder is not implemented for FlexFloat.")
+
+
+def sin(x: FlexFloat) -> FlexFloat:
+    """Return the sine of x (not implemented)."""
+    raise NotImplementedError("sin is not implemented for FlexFloat.")
+
+
+def sinh(x: FlexFloat) -> FlexFloat:
+    """Return the hyperbolic sine of x (not implemented)."""
+    raise NotImplementedError("sinh is not implemented for FlexFloat.")
+
+
+def tan(x: FlexFloat) -> FlexFloat:
+    """Return the tangent of x (not implemented)."""
+    raise NotImplementedError("tan is not implemented for FlexFloat.")
+
+
+def tanh(x: FlexFloat) -> FlexFloat:
+    """Return the hyperbolic tangent of x (not implemented)."""
+    raise NotImplementedError("tanh is not implemented for FlexFloat.")
+
+
+def trunc(x: FlexFloat) -> FlexFloat:
+    """Return the integer part of x (not implemented)."""
+    raise NotImplementedError("trunc is not implemented for FlexFloat.")
+
+
+def ulp(x: FlexFloat) -> FlexFloat:
+    """Return the value of the least significant bit of x (not implemented)."""
+    raise NotImplementedError("ulp is not implemented for FlexFloat.")
+
+
+def fma(x: FlexFloat, y: FlexFloat, z: FlexFloat) -> FlexFloat:
+    """Return x * y + z (not implemented)."""
+    raise NotImplementedError("fma is not implemented for FlexFloat.")

--- a/flexfloat/math.py
+++ b/flexfloat/math.py
@@ -1,164 +1,383 @@
 """Math module for FlexFloat, similar to Python's math module.
 
-Provides mathematical functions that operate on FlexFloat instances.
+This module provides mathematical functions that operate on FlexFloat instances,
+mirroring the interface of Python's built-in math module where possible.
+Most functions are designed to work with FlexFloat objects, enabling arbitrary-precision
+floating-point arithmetic.
+
+Example:
+    from flexfloat.math import sqrt, exp, pow
+    from flexfloat import FlexFloat
+    a = FlexFloat.from_float(2.0)
+    b = sqrt(a)
+    print(b)
+    # Output: FlexFloat(...)
 """
 
 import math
 from typing import Final, Iterable
+
 from .core import FlexFloat
 
 # Constants
 e: Final[FlexFloat] = FlexFloat.from_float(math.e)
+"""The mathematical constant e (Euler's number) as a FlexFloat."""
 pi: Final[FlexFloat] = FlexFloat.from_float(math.pi)
+"""The mathematical constant pi as a FlexFloat."""
 inf: Final[FlexFloat] = FlexFloat.infinity()
+"""Positive infinity as a FlexFloat."""
 nan: Final[FlexFloat] = FlexFloat.nan()
+"""Not-a-Number (NaN) as a FlexFloat."""
 tau: Final[FlexFloat] = FlexFloat.from_float(math.tau)
+"""The mathematical constant tau (2*pi) as a FlexFloat."""
 
 _0_5: Final[FlexFloat] = FlexFloat.from_float(0.5)
+"""The FlexFloat representation of 0.5."""
 
 
-# Math-like functions for FlexFloat
 def exp(x: FlexFloat) -> FlexFloat:
-    """Return e raised to the power of x (where x is a FlexFloat)."""
+    """Return e raised to the power of x (where x is a FlexFloat).
+
+    Args:
+        x (FlexFloat): The exponent value.
+
+    Returns:
+        FlexFloat: The value of e**x as a FlexFloat.
+    """
     return e**x
 
 
 def pow(base: FlexFloat, exp: FlexFloat) -> FlexFloat:
-    """Return base raised to the power of exp (both are FlexFloat instances)."""
+    """Return base raised to the power of exp (both are FlexFloat instances).
+
+    Args:
+        base (FlexFloat): The base value.
+        exp (FlexFloat): The exponent value.
+
+    Returns:
+        FlexFloat: The value of base**exp as a FlexFloat.
+    """
     return base**exp
 
 
 def copysign(x: FlexFloat, y: FlexFloat) -> FlexFloat:
-    """Return a FlexFloat with the magnitude of x and the sign of y."""
+    """Return a FlexFloat with the magnitude of x and the sign of y.
+
+    Args:
+        x (FlexFloat): The value whose magnitude is used.
+        y (FlexFloat): The value whose sign is used.
+
+    Returns:
+        FlexFloat: A FlexFloat with the magnitude of x and the sign of y.
+    """
     result = x.copy()
     result.sign = y.sign
     return result
 
 
 def fabs(x: FlexFloat) -> FlexFloat:
-    """Return the absolute value of x."""
+    """Return the absolute value of x.
+
+    Args:
+        x (FlexFloat): The value to get the absolute value of.
+
+    Returns:
+        FlexFloat: The absolute value of x.
+    """
     return abs(x)
 
 
 def isinf(x: FlexFloat) -> bool:
-    """Check if x is positive or negative infinity."""
+    """Check if x is positive or negative infinity.
+
+    Args:
+        x (FlexFloat): The value to check.
+
+    Returns:
+        bool: True if x is infinity, False otherwise.
+    """
     return x.is_infinity()
 
 
 def isnan(x: FlexFloat) -> bool:
-    """Check if x is NaN (not a number)."""
+    """Check if x is NaN (not a number).
+
+    Args:
+        x (FlexFloat): The value to check.
+
+    Returns:
+        bool: True if x is NaN, False otherwise.
+    """
     return x.is_nan()
 
 
 def isfinite(x: FlexFloat) -> bool:
-    """Check if x is neither an infinity nor NaN."""
+    """Check if x is neither an infinity nor NaN.
+
+    Args:
+        x (FlexFloat): The value to check.
+
+    Returns:
+        bool: True if x is finite, False otherwise.
+    """
     return not x.is_infinity() and not x.is_nan()
 
 
 def sqrt(x: FlexFloat) -> FlexFloat:
-    """Return the square root of x (using power operator)."""
+    """Return the square root of x (using power operator).
+
+    Args:
+        x (FlexFloat): The value to compute the square root of.
+
+    Returns:
+        FlexFloat: The square root of x.
+    """
     return x**_0_5
 
 
 # Unimplemented functions
 def acos(x: FlexFloat) -> FlexFloat:
-    """Return the arc cosine of x (not implemented)."""
+    """Return the arc cosine of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the arc cosine of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("acos is not implemented for FlexFloat.")
 
 
 def acosh(x: FlexFloat) -> FlexFloat:
-    """Return the hyperbolic arc cosine of x (not implemented)."""
+    """Return the hyperbolic arc cosine of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the hyperbolic arc cosine of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("acosh is not implemented for FlexFloat.")
 
 
 def asin(x: FlexFloat) -> FlexFloat:
-    """Return the arc sine of x (not implemented)."""
+    """Return the arc sine of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the arc sine of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("asin is not implemented for FlexFloat.")
 
 
 def asinh(x: FlexFloat) -> FlexFloat:
-    """Return the hyperbolic arc sine of x (not implemented)."""
+    """Return the hyperbolic arc sine of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the hyperbolic arc sine of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("asinh is not implemented for FlexFloat.")
 
 
 def atan(x: FlexFloat) -> FlexFloat:
-    """Return the arc tangent of x (not implemented)."""
+    """Return the arc tangent of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the arc tangent of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("atan is not implemented for FlexFloat.")
 
 
 def atan2(y: FlexFloat, x: FlexFloat) -> FlexFloat:
-    """Return the arc tangent of y/x (not implemented)."""
+    """Return the arc tangent of y/x (not implemented).
+
+    Args:
+        y (FlexFloat): The numerator value.
+        x (FlexFloat): The denominator value.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("atan2 is not implemented for FlexFloat.")
 
 
 def atanh(x: FlexFloat) -> FlexFloat:
-    """Return the hyperbolic arc tangent of x (not implemented)."""
+    """Return the hyperbolic arc tangent of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the hyperbolic arc tangent of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("atanh is not implemented for FlexFloat.")
 
 
 def cbrt(x: FlexFloat) -> FlexFloat:
-    """Return the cube root of x (not implemented)."""
+    """Return the cube root of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the cube root of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("cbrt is not implemented for FlexFloat.")
 
 
 def ceil(x: FlexFloat) -> FlexFloat:
-    """Return the ceiling of x (not implemented)."""
+    """Return the ceiling of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the ceiling of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("ceil is not implemented for FlexFloat.")
 
 
 # Not implemented functions
 def dist(p: Iterable[FlexFloat], q: Iterable[FlexFloat]) -> FlexFloat:
-    """Return the Euclidean distance between two points p and q (not implemented)."""
+    """Return the Euclidean distance between two points p and q (not implemented).
+
+    Args:
+        p (Iterable[FlexFloat]): The first point coordinates.
+        q (Iterable[FlexFloat]): The second point coordinates.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("dist is not implemented for FlexFloat.")
 
 
 def erf(x: FlexFloat) -> FlexFloat:
-    """Return the error function of x (not implemented)."""
+    """Return the error function of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the error function of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("erf is not implemented for FlexFloat.")
 
 
 def erfc(x: FlexFloat) -> FlexFloat:
-    """Return the complementary error function of x (not implemented)."""
+    """Return the complementary error function of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the complementary error function of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("erfc is not implemented for FlexFloat.")
 
 
 def expm1(x: FlexFloat) -> FlexFloat:
-    """Return e raised to the power of x, minus 1 (not implemented)."""
+    """Return e raised to the power of x, minus 1 (not implemented).
+
+    Args:
+        x (FlexFloat): The exponent value.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("expm1 is not implemented for FlexFloat.")
 
 
 def factorial(x: FlexFloat) -> FlexFloat:
-    """Return the factorial of x (not implemented)."""
+    """Return the factorial of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the factorial of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("factorial is not implemented for FlexFloat.")
 
 
 def fmod(x: FlexFloat, y: FlexFloat) -> FlexFloat:
-    """Return the remainder of x divided by y (not implemented)."""
+    """Return the remainder of x divided by y (not implemented).
+
+    Args:
+        x (FlexFloat): The dividend value.
+        y (FlexFloat): The divisor value.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("fmod is not implemented for FlexFloat.")
 
 
 def frexp(x: FlexFloat) -> tuple[FlexFloat, int]:
-    """Return the mantissa and exponent of x (not implemented)."""
+    """Return the mantissa and exponent of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to decompose into mantissa and exponent.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("frexp is not implemented for FlexFloat.")
 
 
 def fsum(seq: Iterable[FlexFloat]) -> FlexFloat:
-    """Return an accurate floating-point sum of the values in seq (not implemented)."""
+    """Return an accurate floating-point sum of the values in seq (not implemented).
+
+    Args:
+        seq (Iterable[FlexFloat]): The sequence of values to sum.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("fsum is not implemented for FlexFloat.")
 
 
 def gamma(x: FlexFloat) -> FlexFloat:
-    """Return the gamma function of x (not implemented)."""
+    """Return the gamma function of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the gamma function of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("gamma is not implemented for FlexFloat.")
 
 
 def gcd(*integers: FlexFloat) -> FlexFloat:
-    """Return the greatest common divisor of the integers (not implemented)."""
+    """Return the greatest common divisor of the integers (not implemented).
+
+    Args:
+        *integers (FlexFloat): The integers to compute the gcd of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("gcd is not implemented for FlexFloat.")
 
 
 def hypot(*coordinates: FlexFloat) -> FlexFloat:
-    """Return the Euclidean norm, sqrt(x1*x1 + x2*x2 + ... + xn*xn) (not implemented)."""
+    """Return the Euclidean norm, sqrt(x1*x1 + x2*x2 + ... + xn*xn)
+    (not implemented).
+
+    Args:
+        *coordinates (FlexFloat): The coordinates to compute the norm of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("hypot is not implemented for FlexFloat.")
 
 
@@ -169,100 +388,255 @@ def isclose(
     rel_tol: FlexFloat = FlexFloat.from_float(1e-09),
     abs_tol: FlexFloat = FlexFloat.from_float(0.0),
 ) -> bool:
-    """Check if two FlexFloat instances are close in value (not implemented)."""
+    """Check if two FlexFloat instances are close in value (not implemented).
+
+    Args:
+        a (FlexFloat): The first value to compare.
+        b (FlexFloat): The second value to compare.
+        rel_tol (FlexFloat, optional): The relative tolerance. Defaults to 1e-09.
+        abs_tol (FlexFloat, optional): The absolute tolerance. Defaults to 0.0.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("isclose is not implemented for FlexFloat.")
 
 
 def lcm(*integers: FlexFloat) -> FlexFloat:
-    """Return the least common multiple of the integers (not implemented)."""
+    """Return the least common multiple of the integers (not implemented).
+
+    Args:
+        *integers (FlexFloat): The integers to compute the lcm of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("lcm is not implemented for FlexFloat.")
 
 
 def ldexp(x: FlexFloat, i: int) -> FlexFloat:
-    """Return x * (2**i) (not implemented)."""
+    """Return x * (2**i) (not implemented).
+
+    Args:
+        x (FlexFloat): The value to scale.
+        i (int): The exponent value.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("ldexp is not implemented for FlexFloat.")
 
 
 def lgamma(x: FlexFloat) -> FlexFloat:
-    """Return the natural logarithm of the absolute value of the gamma function of x (not implemented)."""
+    """Return the natural logarithm of the absolute value of the gamma function of x
+    (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the natural logarithm of the gamma
+          function of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("lgamma is not implemented for FlexFloat.")
 
 
 def log(x: FlexFloat, base: FlexFloat = e) -> FlexFloat:
-    """Return the logarithm of x to the given base (not implemented)."""
+    """Return the logarithm of x to the given base (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the logarithm of.
+        base (FlexFloat, optional): The base of the logarithm. Defaults to e.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("log is not implemented for FlexFloat.")
 
 
 def log10(x: FlexFloat) -> FlexFloat:
-    """Return the base-10 logarithm of x (not implemented)."""
+    """Return the base-10 logarithm of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the base-10 logarithm of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("log10 is not implemented for FlexFloat.")
 
 
 def log1p(x: FlexFloat) -> FlexFloat:
-    """Return the natural logarithm of 1 + x (not implemented)."""
+    """Return the natural logarithm of 1 + x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the natural logarithm of 1 + x.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("log1p is not implemented for FlexFloat.")
 
 
 def log2(x: FlexFloat) -> FlexFloat:
-    """Return the base-2 logarithm of x (not implemented)."""
+    """Return the base-2 logarithm of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the base-2 logarithm of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("log2 is not implemented for FlexFloat.")
 
 
 def modf(x: FlexFloat) -> tuple[FlexFloat, FlexFloat]:
-    """Return the fractional and integer parts of x (not implemented)."""
+    """Return the fractional and integer parts of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to split into fractional and integer parts.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("modf is not implemented for FlexFloat.")
 
 
 def nextafter(x: FlexFloat, y: FlexFloat, *, steps: int | None = None) -> FlexFloat:
-    """Return the next representable FlexFloat value after x towards y (not implemented)."""
+    """Return the next representable FlexFloat value after x towards y
+    (not implemented).
+
+    Args:
+        x (FlexFloat): The starting value.
+        y (FlexFloat): The target value.
+        steps (int | None, optional): The number of steps to take. Defaults to None.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("nextafter is not implemented for FlexFloat.")
 
 
 def perm(n: FlexFloat, k: FlexFloat | None = None) -> FlexFloat:
-    """Return the number of ways to choose k items from n items without repetition (not implemented)."""
+    """Return the number of ways to choose k items from n items without repetition
+    (not implemented).
+
+    Args:
+        n (FlexFloat): The total number of items.
+        k (FlexFloat | None, optional): The number of items to choose. Defaults to None.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("perm is not implemented for FlexFloat.")
 
 
 def radians(x: FlexFloat) -> FlexFloat:
-    """Convert angle x from degrees to radians (not implemented)."""
+    """Convert angle x from degrees to radians (not implemented).
+
+    Args:
+        x (FlexFloat): The angle in degrees.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("radians is not implemented for FlexFloat.")
 
 
 def remainder(x: FlexFloat, y: FlexFloat) -> FlexFloat:
-    """Return the remainder of x divided by y (not implemented)."""
+    """Return the remainder of x divided by y (not implemented).
+
+    Args:
+        x (FlexFloat): The dividend value.
+        y (FlexFloat): The divisor value.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("remainder is not implemented for FlexFloat.")
 
 
 def sin(x: FlexFloat) -> FlexFloat:
-    """Return the sine of x (not implemented)."""
+    """Return the sine of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the sine of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("sin is not implemented for FlexFloat.")
 
 
 def sinh(x: FlexFloat) -> FlexFloat:
-    """Return the hyperbolic sine of x (not implemented)."""
+    """Return the hyperbolic sine of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the hyperbolic sine of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("sinh is not implemented for FlexFloat.")
 
 
 def tan(x: FlexFloat) -> FlexFloat:
-    """Return the tangent of x (not implemented)."""
+    """Return the tangent of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the tangent of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("tan is not implemented for FlexFloat.")
 
 
 def tanh(x: FlexFloat) -> FlexFloat:
-    """Return the hyperbolic tangent of x (not implemented)."""
+    """Return the hyperbolic tangent of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the hyperbolic tangent of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("tanh is not implemented for FlexFloat.")
 
 
 def trunc(x: FlexFloat) -> FlexFloat:
-    """Return the integer part of x (not implemented)."""
+    """Return the integer part of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to truncate.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("trunc is not implemented for FlexFloat.")
 
 
 def ulp(x: FlexFloat) -> FlexFloat:
-    """Return the value of the least significant bit of x (not implemented)."""
+    """Return the value of the least significant bit of x (not implemented).
+
+    Args:
+        x (FlexFloat): The value to compute the least significant bit of.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("ulp is not implemented for FlexFloat.")
 
 
 def fma(x: FlexFloat, y: FlexFloat, z: FlexFloat) -> FlexFloat:
-    """Return x * y + z (not implemented)."""
+    """Return x * y + z (not implemented).
+
+    Args:
+        x (FlexFloat): The first multiplicand.
+        y (FlexFloat): The second multiplicand.
+        z (FlexFloat): The value to add to the product.
+
+    Raises:
+        NotImplementedError: Always, as this function is not implemented.
+    """
     raise NotImplementedError("fma is not implemented for FlexFloat.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flexfloat"
-version = "0.3.0"
+version = "0.3.1"
 description = "A library for arbitrary precision floating point arithmetic"
 readme = "README.md"
 authors = [

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,10 +1,11 @@
 """Tests for flexfloat.math module functions."""
 
+import math  # For reference values in tests
 import unittest
+
 from flexfloat import FlexFloat
 from flexfloat import math as ffmath
 from tests import FlexFloatTestCase
-import math  # For reference values in tests
 
 
 class TestFlexFloatMath(FlexFloatTestCase):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,0 +1,579 @@
+"""Tests for flexfloat.math module functions."""
+
+import unittest
+from flexfloat import FlexFloat
+from flexfloat import math as ffmath
+from tests import FlexFloatTestCase
+import math  # For reference values in tests
+
+
+class TestFlexFloatMath(FlexFloatTestCase):
+    """Test class for FlexFloat math module functions."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_values = [0.0, 1.0, -1.0, 0.5, 2.0, 3.14159, -3.14159, 10.0, -10.0]
+        self.small_positive = 1e-10
+        self.large_positive = 1e10
+
+    # Tests for constants
+    def test_constants(self):
+        """Test that math constants are properly defined."""
+        self.assertIsInstance(ffmath.e, FlexFloat)
+        self.assertIsInstance(ffmath.pi, FlexFloat)
+        self.assertIsInstance(ffmath.inf, FlexFloat)
+        self.assertIsInstance(ffmath.nan, FlexFloat)
+        self.assertIsInstance(ffmath.tau, FlexFloat)
+
+        # Check approximate values
+        self.assertAlmostEqualRel(ffmath.e.to_float(), math.e)
+        self.assertAlmostEqualRel(ffmath.pi.to_float(), math.pi)
+        self.assertAlmostEqualRel(ffmath.tau.to_float(), math.tau)
+        self.assertTrue(ffmath.inf.is_infinity())
+        self.assertTrue(ffmath.nan.is_nan())
+
+    # Tests for implemented functions
+    def test_exp(self):
+        """Test exp function."""
+        test_cases = [0.0, 1.0, -1.0, 0.5, 2.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.exp(x)
+                expected = math.exp(value)
+                self.assertAlmostEqualRel(result.to_float(), expected, tolerance=1e-6)
+
+    def test_pow(self):
+        """Test pow function."""
+        test_cases = [
+            (2.0, 3.0),
+            (1.5, 2.0),
+            (4.0, 0.5),
+            (10.0, 2.0),
+            (2.0, -1.0),
+        ]
+        for base, exp in test_cases:
+            with self.subTest(base=base, exp=exp):
+                base_ff = FlexFloat.from_float(base)
+                exp_ff = FlexFloat.from_float(exp)
+                result = ffmath.pow(base_ff, exp_ff)
+                expected = math.pow(base, exp)
+                self.assertAlmostEqualRel(result.to_float(), expected, tolerance=1e-6)
+
+    def test_copysign(self):
+        """Test copysign function."""
+        test_cases = [
+            (5.0, 1.0),
+            (5.0, -1.0),
+            (-5.0, 1.0),
+            (-5.0, -1.0),
+            (0.0, 1.0),
+            (0.0, -1.0),
+        ]
+        for mag, sign in test_cases:
+            with self.subTest(mag=mag, sign=sign):
+                mag_ff = FlexFloat.from_float(mag)
+                sign_ff = FlexFloat.from_float(sign)
+                result = ffmath.copysign(mag_ff, sign_ff)
+                expected = math.copysign(mag, sign)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    def test_fabs(self):
+        """Test fabs function."""
+        for value in self.test_values:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.fabs(x)
+                expected = math.fabs(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    def test_isinf(self):
+        """Test isinf function."""
+        # Test finite values
+        for value in self.test_values:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                self.assertEqual(ffmath.isinf(x), math.isinf(value))
+
+        # Test infinity
+        pos_inf = FlexFloat.infinity()
+        neg_inf = FlexFloat.infinity(sign=True)
+        self.assertTrue(ffmath.isinf(pos_inf))
+        self.assertTrue(ffmath.isinf(neg_inf))
+
+        # Test NaN
+        nan_val = FlexFloat.nan()
+        self.assertFalse(ffmath.isinf(nan_val))
+
+    def test_isnan(self):
+        """Test isnan function."""
+        # Test finite values
+        for value in self.test_values:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                self.assertEqual(ffmath.isnan(x), math.isnan(value))
+
+        # Test infinity
+        pos_inf = FlexFloat.infinity()
+        neg_inf = FlexFloat.infinity(sign=True)
+        self.assertFalse(ffmath.isnan(pos_inf))
+        self.assertFalse(ffmath.isnan(neg_inf))
+
+        # Test NaN
+        nan_val = FlexFloat.nan()
+        self.assertTrue(ffmath.isnan(nan_val))
+
+    def test_isfinite(self):
+        """Test isfinite function."""
+        # Test finite values
+        for value in self.test_values:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                self.assertTrue(ffmath.isfinite(x))
+
+        # Test infinity
+        pos_inf = FlexFloat.infinity()
+        neg_inf = FlexFloat.infinity(sign=True)
+        self.assertFalse(ffmath.isfinite(pos_inf))
+        self.assertFalse(ffmath.isfinite(neg_inf))
+
+        # Test NaN
+        nan_val = FlexFloat.nan()
+        self.assertFalse(ffmath.isfinite(nan_val))
+
+    def test_sqrt(self):
+        """Test sqrt function."""
+        test_cases = [0.0, 1.0, 4.0, 9.0, 16.0, 0.25, 2.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.sqrt(x)
+                expected = math.sqrt(value)
+                self.assertAlmostEqualRel(result.to_float(), expected, tolerance=1e-6)
+
+    # Tests for unimplemented functions
+    @unittest.skip("acos is not implemented yet")
+    def test_acos(self):
+        """Test acos function."""
+        test_cases = [0.0, 0.5, 1.0, -1.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.acos(x)
+                expected = math.acos(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("acosh is not implemented yet")
+    def test_acosh(self):
+        """Test acosh function."""
+        test_cases = [1.0, 2.0, 5.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.acosh(x)
+                expected = math.acosh(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("asin is not implemented yet")
+    def test_asin(self):
+        """Test asin function."""
+        test_cases = [0.0, 0.5, 1.0, -1.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.asin(x)
+                expected = math.asin(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("asinh is not implemented yet")
+    def test_asinh(self):
+        """Test asinh function."""
+        test_cases = [0.0, 1.0, -1.0, 2.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.asinh(x)
+                expected = math.asinh(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("atan is not implemented yet")
+    def test_atan(self):
+        """Test atan function."""
+        test_cases = [0.0, 1.0, -1.0, 2.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.atan(x)
+                expected = math.atan(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("atan2 is not implemented yet")
+    def test_atan2(self):
+        """Test atan2 function."""
+        test_cases = [(1.0, 1.0), (1.0, 0.0), (0.0, 1.0), (-1.0, 1.0)]
+        for y, x in test_cases:
+            with self.subTest(y=y, x=x):
+                y_ff = FlexFloat.from_float(y)
+                x_ff = FlexFloat.from_float(x)
+                result = ffmath.atan2(y_ff, x_ff)
+                expected = math.atan2(y, x)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("atanh is not implemented yet")
+    def test_atanh(self):
+        """Test atanh function."""
+        test_cases = [0.0, 0.5, -0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.atanh(x)
+                expected = math.atanh(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("cbrt is not implemented yet")
+    def test_cbrt(self):
+        """Test cbrt function."""
+        test_cases = [0.0, 1.0, 8.0, 27.0, -8.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.cbrt(x)
+                expected = math.cbrt(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("ceil is not implemented yet")
+    def test_ceil(self):
+        """Test ceil function."""
+        test_cases = [0.0, 1.5, -1.5, 2.1, -2.1]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.ceil(x)
+                expected = math.ceil(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("dist is not implemented yet")
+    def test_dist(self):
+        """Test dist function."""
+        p = [FlexFloat.from_float(1.0), FlexFloat.from_float(2.0)]
+        q = [FlexFloat.from_float(4.0), FlexFloat.from_float(6.0)]
+        result = ffmath.dist(p, q)
+        expected = math.dist([1.0, 2.0], [4.0, 6.0])
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("erf is not implemented yet")
+    def test_erf(self):
+        """Test erf function."""
+        test_cases = [0.0, 1.0, -1.0, 0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.erf(x)
+                expected = math.erf(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("erfc is not implemented yet")
+    def test_erfc(self):
+        """Test erfc function."""
+        test_cases = [0.0, 1.0, -1.0, 0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.erfc(x)
+                expected = math.erfc(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("expm1 is not implemented yet")
+    def test_expm1(self):
+        """Test expm1 function."""
+        test_cases = [0.0, 1.0, -1.0, 0.1]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.expm1(x)
+                expected = math.expm1(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("factorial is not implemented yet")
+    def test_factorial(self):
+        """Test factorial function."""
+        test_cases = [0.0, 1.0, 2.0, 5.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.factorial(x)
+                expected = math.factorial(int(value))
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("fmod is not implemented yet")
+    def test_fmod(self):
+        """Test fmod function."""
+        test_cases = [(7.0, 3.0), (10.0, 3.0), (5.5, 2.0)]
+        for x_val, y_val in test_cases:
+            with self.subTest(x=x_val, y=y_val):
+                x = FlexFloat.from_float(x_val)
+                y = FlexFloat.from_float(y_val)
+                result = ffmath.fmod(x, y)
+                expected = math.fmod(x_val, y_val)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("frexp is not implemented yet")
+    def test_frexp(self):
+        """Test frexp function."""
+        test_cases = [1.0, 2.0, 3.5, 0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                mantissa, exponent = ffmath.frexp(x)
+                expected_mantissa, expected_exponent = math.frexp(value)
+                self.assertAlmostEqualRel(mantissa.to_float(), expected_mantissa)
+                self.assertEqual(exponent, expected_exponent)
+
+    @unittest.skip("fsum is not implemented yet")
+    def test_fsum(self):
+        """Test fsum function."""
+        seq = [FlexFloat.from_float(x) for x in [1.0, 2.0, 3.0]]
+        result = ffmath.fsum(seq)
+        expected = math.fsum([1.0, 2.0, 3.0])
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("gamma is not implemented yet")
+    def test_gamma(self):
+        """Test gamma function."""
+        test_cases = [1.0, 2.0, 3.0, 0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.gamma(x)
+                expected = math.gamma(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("gcd is not implemented yet")
+    def test_gcd(self):
+        """Test gcd function."""
+        args = [FlexFloat.from_float(x) for x in [12.0, 18.0]]
+        result = ffmath.gcd(*args)
+        expected = math.gcd(12, 18)
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("hypot is not implemented yet")
+    def test_hypot(self):
+        """Test hypot function."""
+        args = [FlexFloat.from_float(x) for x in [3.0, 4.0]]
+        result = ffmath.hypot(*args)
+        expected = math.hypot(3.0, 4.0)
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("isclose is not implemented yet")
+    def test_isclose(self):
+        """Test isclose function."""
+        a = FlexFloat.from_float(1.0)
+        b = FlexFloat.from_float(1.0001)
+        result = ffmath.isclose(a, b)
+        expected = math.isclose(1.0, 1.0001)
+        self.assertEqual(result, expected)
+
+    @unittest.skip("lcm is not implemented yet")
+    def test_lcm(self):
+        """Test lcm function."""
+        args = [FlexFloat.from_float(x) for x in [12.0, 18.0]]
+        result = ffmath.lcm(*args)
+        expected = math.lcm(12, 18)
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("ldexp is not implemented yet")
+    def test_ldexp(self):
+        """Test ldexp function."""
+        x = FlexFloat.from_float(1.0)
+        result = ffmath.ldexp(x, 2)
+        expected = math.ldexp(1.0, 2)
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("lgamma is not implemented yet")
+    def test_lgamma(self):
+        """Test lgamma function."""
+        test_cases = [1.0, 2.0, 3.0, 0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.lgamma(x)
+                expected = math.lgamma(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("log is not implemented yet")
+    def test_log(self):
+        """Test log function."""
+        test_cases = [1.0, 2.0, 10.0, math.e]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.log(x)
+                expected = math.log(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("log10 is not implemented yet")
+    def test_log10(self):
+        """Test log10 function."""
+        test_cases = [1.0, 10.0, 100.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.log10(x)
+                expected = math.log10(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("log1p is not implemented yet")
+    def test_log1p(self):
+        """Test log1p function."""
+        test_cases = [0.0, 1.0, 0.1]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.log1p(x)
+                expected = math.log1p(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("log2 is not implemented yet")
+    def test_log2(self):
+        """Test log2 function."""
+        test_cases = [1.0, 2.0, 4.0, 8.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.log2(x)
+                expected = math.log2(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("modf is not implemented yet")
+    def test_modf(self):
+        """Test modf function."""
+        test_cases = [1.5, 2.7, -1.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                fractional, integral = ffmath.modf(x)
+                expected_fractional, expected_integral = math.modf(value)
+                self.assertAlmostEqualRel(fractional.to_float(), expected_fractional)
+                self.assertAlmostEqualRel(integral.to_float(), expected_integral)
+
+    @unittest.skip("nextafter is not implemented yet")
+    def test_nextafter(self):
+        """Test nextafter function."""
+        x = FlexFloat.from_float(1.0)
+        y = FlexFloat.from_float(2.0)
+        result = ffmath.nextafter(x, y)
+        expected = math.nextafter(1.0, 2.0)
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("perm is not implemented yet")
+    def test_perm(self):
+        """Test perm function."""
+        n = FlexFloat.from_float(5.0)
+        k = FlexFloat.from_float(3.0)
+        result = ffmath.perm(n, k)
+        expected = math.perm(5, 3)
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("radians is not implemented yet")
+    def test_radians(self):
+        """Test radians function."""
+        test_cases = [0.0, 90.0, 180.0, 360.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.radians(x)
+                expected = math.radians(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("remainder is not implemented yet")
+    def test_remainder(self):
+        """Test remainder function."""
+        test_cases = [(7.0, 3.0), (10.0, 3.0), (5.5, 2.0)]
+        for x_val, y_val in test_cases:
+            with self.subTest(x=x_val, y=y_val):
+                x = FlexFloat.from_float(x_val)
+                y = FlexFloat.from_float(y_val)
+                result = ffmath.remainder(x, y)
+                expected = math.remainder(x_val, y_val)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("sin is not implemented yet")
+    def test_sin(self):
+        """Test sin function."""
+        test_cases = [0.0, math.pi / 2, math.pi, 3 * math.pi / 2]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.sin(x)
+                expected = math.sin(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("sinh is not implemented yet")
+    def test_sinh(self):
+        """Test sinh function."""
+        test_cases = [0.0, 1.0, -1.0, 2.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.sinh(x)
+                expected = math.sinh(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("tan is not implemented yet")
+    def test_tan(self):
+        """Test tan function."""
+        test_cases = [0.0, math.pi / 4, math.pi / 3]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.tan(x)
+                expected = math.tan(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("tanh is not implemented yet")
+    def test_tanh(self):
+        """Test tanh function."""
+        test_cases = [0.0, 1.0, -1.0, 2.0]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.tanh(x)
+                expected = math.tanh(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("trunc is not implemented yet")
+    def test_trunc(self):
+        """Test trunc function."""
+        test_cases = [1.5, 2.7, -1.5, -2.7]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.trunc(x)
+                expected = math.trunc(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("ulp is not implemented yet")
+    def test_ulp(self):
+        """Test ulp function."""
+        test_cases = [1.0, 2.0, 0.5]
+        for value in test_cases:
+            with self.subTest(value=value):
+                x = FlexFloat.from_float(value)
+                result = ffmath.ulp(x)
+                expected = math.ulp(value)
+                self.assertAlmostEqualRel(result.to_float(), expected)
+
+    @unittest.skip("fma is not implemented yet")
+    def test_fma(self):
+        """Test fma function."""
+        x = FlexFloat.from_float(2.0)
+        y = FlexFloat.from_float(3.0)
+        z = FlexFloat.from_float(1.0)
+        result = ffmath.fma(x, y, z)
+        # fma(x, y, z) = x * y + z
+        expected = 2.0 * 3.0 + 1.0
+        self.assertAlmostEqualRel(result.to_float(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -3,7 +3,8 @@
 import math
 import unittest
 
-from flexfloat import FlexFloat, ListBoolBitArray, math as ffmath
+from flexfloat import FlexFloat, ListBoolBitArray
+from flexfloat import math as ffmath
 from tests import FlexFloatTestCase
 
 

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -3,7 +3,7 @@
 import math
 import unittest
 
-from flexfloat import FlexFloat, ListBoolBitArray
+from flexfloat import FlexFloat, ListBoolBitArray, math as ffmath
 from tests import FlexFloatTestCase
 
 
@@ -387,14 +387,14 @@ class TestExponential(FlexFloatTestCase):
     def test_flexfloat_exp_zero_returns_one(self):
         """Test that exp(0) returns 1."""
         zero = FlexFloat.from_float(0.0)
-        result = zero.exp()
+        result = ffmath.exp(zero)
         expected = math.exp(0.0)
         self.assertAlmostEqualRel(result.to_float(), expected)
 
     def test_flexfloat_exp_one_returns_e(self):
         """Test that exp(1) returns e."""
         one = FlexFloat.from_float(1.0)
-        result = one.exp()
+        result = ffmath.exp(one)
         expected = math.exp(1.0)
         self.assertAlmostEqualRel(result.to_float(), expected)
 
@@ -404,7 +404,7 @@ class TestExponential(FlexFloatTestCase):
         for val in test_cases:
             with self.subTest(value=val):
                 ff = FlexFloat.from_float(val)
-                result = ff.exp()
+                result = ffmath.exp(ff)
                 expected = math.exp(val)
                 self.assertAlmostEqualRel(result.to_float(), expected)
 
@@ -414,7 +414,7 @@ class TestExponential(FlexFloatTestCase):
         for val in test_cases:
             with self.subTest(value=val):
                 ff = FlexFloat.from_float(val)
-                result = ff.exp()
+                result = ffmath.exp(ff)
                 expected = math.exp(val)
                 if expected > 1e100:
                     # For very large results, check that it doesn't overflow to infinity
@@ -429,7 +429,7 @@ class TestExponential(FlexFloatTestCase):
         for val in test_cases:
             with self.subTest(value=val):
                 ff = FlexFloat.from_float(val)
-                result = ff.exp()
+                result = ffmath.exp(ff)
                 expected = math.exp(val)
                 if expected < 1e-100:
                     # For very small results, check that it doesn't underflow to zero
@@ -441,45 +441,45 @@ class TestExponential(FlexFloatTestCase):
     def test_flexfloat_exp_handles_nan(self):
         """Test that exp(NaN) returns NaN."""
         nan = FlexFloat.nan()
-        result = nan.exp()
+        result = ffmath.exp(nan)
         self.assertTrue(result.is_nan())
 
     def test_flexfloat_exp_handles_infinity(self):
         """Test exp with infinity operands."""
         # exp(+inf) = +inf
         pos_inf = FlexFloat.infinity()
-        result1 = pos_inf.exp()
+        result1 = ffmath.exp(pos_inf)
         self.assertTrue(result1.is_infinity())
         self.assertFalse(result1.sign)
 
         # exp(-inf) = 0
         neg_inf = FlexFloat.infinity(sign=True)
-        result2 = neg_inf.exp()
+        result2 = ffmath.exp(neg_inf)
         self.assertTrue(result2.is_zero())
 
     def test_flexfloat_exp_mathematical_constants(self):
         """Test exp with mathematical constants."""
         # exp(ln(2)) = 2
         ln2 = FlexFloat.from_float(math.log(2.0))
-        result = ln2.exp()
+        result = ffmath.exp(ln2)
         self.assertAlmostEqualRel(result.to_float(), 2.0)
 
         # exp(ln(10)) = 10
         ln10 = FlexFloat.from_float(math.log(10.0))
-        result = ln10.exp()
+        result = ffmath.exp(ln10)
         self.assertAlmostEqualRel(result.to_float(), 10.0)
 
     def test_flexfloat_exp_extreme_precision(self):
         """Test exp with extreme precision cases."""
         # Very small values near zero
         tiny = FlexFloat.from_float(1e-15)
-        result = tiny.exp()
+        result = ffmath.exp(tiny)
         expected = math.exp(1e-15)
         self.assertAlmostEqualRel(result.to_float(), expected)
 
         # Test that exp maintains high precision
         val = FlexFloat.from_float(0.123456789)
-        result = val.exp()
+        result = ffmath.exp(val)
         expected = math.exp(0.123456789)
         self.assertAlmostEqualRel(result.to_float(), expected)
 


### PR DESCRIPTION
- Implement new `flexfloat.math` module providing math-like functions for FlexFloat (exp, pow, copysign, fabs, isinf, isnan, isfinite, sqrt, and constants e/pi/tau/inf/nan).
- Add `tests/test_math.py` with extensive tests for all implemented and unimplemented math functions.
- Refactor FlexFloat core: remove `.exp()` method and class variable `e` (now provided by math module).
- Update `__init__.py` to expose new math module.
- Update `tests/test_power.py` to use `ffmath.exp` and math functions for exponential tests.