### PR TITLE
docs: add comprehensive Sphinx documentation and API reference

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = False
 tag = False
 allow_dirty = True

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch: # Allow manual triggering
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history needed for versioning
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Build documentation
+        run: |
+          cd docs
+          make html
+        env:
+          # Set environment variable to ensure clean build
+          SPHINXBUILD: sphinx-build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/build/html
+
+  # Deployment job
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,14 @@ recursive-include flexfloat *.typed
 recursive-include tests *.py
 recursive-include scripts *.py
 
+recursive-include docs *.bat
+recursive-include docs *.css
+recursive-include docs *.html
+recursive-include docs *.md
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+
 global-exclude *.pyc
 global-exclude __pycache__
 global-exclude .pytest_cache

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,56 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD  ?= sphinx-build
+SOURCEDIR    = source
+BUILDDIR     = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Clean build directory
+clean:
+	rm -rf $(BUILDDIR)/*
+
+# Build HTML documentation
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
+
+# Build HTML documentation with live reload (requires sphinx-autobuild)
+livehtml:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
+
+# Build PDF documentation (requires LaTeX)
+pdf:
+	@$(SPHINXBUILD) -b latex "$(SOURCEDIR)" "$(BUILDDIR)/latex" $(SPHINXOPTS) $(O)
+	@make -C $(BUILDDIR)/latex all-pdf
+
+# Build EPUB documentation
+epub:
+	@$(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)/epub" $(SPHINXOPTS) $(O)
+
+# Check links in documentation
+linkcheck:
+	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck" $(SPHINXOPTS) $(O)
+
+# Build documentation for all supported formats
+all: html epub
+
+# Check documentation for issues
+check:
+	@$(SPHINXBUILD) -b dummy "$(SOURCEDIR)" "$(BUILDDIR)/dummy" -W $(SPHINXOPTS) $(O)
+
+# Build documentation treating warnings as errors
+strict:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" -W $(SPHINXOPTS) $(O)
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,89 @@
+# FlexFloat Documentation
+
+This directory contains the Sphinx documentation for FlexFloat.
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.11 or higher
+- FlexFloat package installed
+
+### Setup
+
+1. Install documentation dependencies:
+   ```bash
+   pip install -e ".[docs]"
+   ```
+
+2. Build the documentation:
+   ```bash
+   cd docs
+   make html
+   ```
+
+3. View the documentation:
+   ```bash
+   # Open docs/build/html/index.html in your browser
+   ```
+
+## Building Documentation
+
+### Basic Build
+```bash
+cd docs
+make html          # Build HTML documentation
+make clean         # Clean build directory
+make linkcheck     # Check for broken links
+```
+
+### Advanced Options
+```bash
+make strict        # Build with warnings as errors
+make livehtml      # Build with live reload (requires sphinx-autobuild)
+```
+
+## Customization
+
+### Theme and Styling
+- Theme: Sphinx RTD Theme
+- Custom CSS: `source/_static/custom.css`
+
+### Configuration
+Main configuration is in `source/conf.py`:
+- Project metadata
+- Extensions
+- Theme options
+- Version information
+
+### Adding Content
+
+#### New Pages
+1. Create `.rst` files in appropriate directories
+2. Add to relevant `toctree` directives
+3. Follow existing structure and style
+
+#### API Documentation
+API docs are automatically generated from docstrings using:
+- `sphinx.ext.autodoc`
+- `sphinx.ext.autosummary`
+- `sphinx.ext.napoleon` (for Google/NumPy style docstrings)
+
+#### Examples
+Add examples in `source/examples/` directory with practical use cases.
+
+### Manual Deployment
+```bash
+# Build documentation
+make html
+
+# Deploy to GitHub Pages (manual)
+# Copy docs/build/html/* to gh-pages branch
+```
+
+## Resources
+
+- [Sphinx Documentation](https://www.sphinx-doc.org/)
+- [reStructuredText Primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
+- [Sphinx RTD Theme](https://sphinx-rtd-theme.readthedocs.io/)
+- [Read the Docs](https://docs.readthedocs.io/)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,78 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+if "%1" == "help" (
+	:help
+	%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+	goto end
+)
+
+if "%1" == "clean" (
+	echo.Cleaning build directory...
+	rmdir /s /q %BUILDDIR% >nul 2>&1
+	echo.Build directory cleaned.
+	goto end
+)
+
+if "%1" == "html" (
+	echo.Building HTML documentation...
+	%SPHINXBUILD% -b html %SOURCEDIR% %BUILDDIR%\html %SPHINXOPTS% %O%
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%\html.
+	goto end
+)
+
+if "%1" == "livehtml" (
+	echo.Starting live HTML build server...
+	sphinx-autobuild %SOURCEDIR% %BUILDDIR%\html %SPHINXOPTS% %O%
+	goto end
+)
+
+if "%1" == "linkcheck" (
+	echo.Checking external links...
+	%SPHINXBUILD% -b linkcheck %SOURCEDIR% %BUILDDIR%\linkcheck %SPHINXOPTS% %O%
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Link check complete; look for any errors in the above output or in %BUILDDIR%\linkcheck\output.txt.
+	goto end
+)
+
+if "%1" == "strict" (
+	echo.Building HTML documentation with warnings as errors...
+	%SPHINXBUILD% -b html %SOURCEDIR% %BUILDDIR%\html -W %SPHINXOPTS% %O%
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished successfully with no warnings.
+	goto end
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:end
+popd

--- a/docs/source/_autosummary/flexfloat.BigIntBitArray.rst
+++ b/docs/source/_autosummary/flexfloat.BigIntBitArray.rst
@@ -1,0 +1,6 @@
+﻿flexfloat.BigIntBitArray
+========================
+
+.. currentmodule:: flexfloat
+
+.. autoclass:: BigIntBitArray

--- a/docs/source/_autosummary/flexfloat.BitArray.rst
+++ b/docs/source/_autosummary/flexfloat.BitArray.rst
@@ -1,0 +1,6 @@
+﻿flexfloat.BitArray
+==================
+
+.. currentmodule:: flexfloat
+
+.. autoclass:: BitArray

--- a/docs/source/_autosummary/flexfloat.FlexFloat.rst
+++ b/docs/source/_autosummary/flexfloat.FlexFloat.rst
@@ -1,0 +1,6 @@
+﻿flexfloat.FlexFloat
+===================
+
+.. currentmodule:: flexfloat
+
+.. autoclass:: FlexFloat

--- a/docs/source/_autosummary/flexfloat.ListBoolBitArray.rst
+++ b/docs/source/_autosummary/flexfloat.ListBoolBitArray.rst
@@ -1,0 +1,6 @@
+﻿flexfloat.ListBoolBitArray
+==========================
+
+.. currentmodule:: flexfloat
+
+.. autoclass:: ListBoolBitArray

--- a/docs/source/_autosummary/flexfloat.ListInt64BitArray.rst
+++ b/docs/source/_autosummary/flexfloat.ListInt64BitArray.rst
@@ -1,0 +1,6 @@
+﻿flexfloat.ListInt64BitArray
+===========================
+
+.. currentmodule:: flexfloat
+
+.. autoclass:: ListInt64BitArray

--- a/docs/source/_autosummary/flexfloat.math.rst
+++ b/docs/source/_autosummary/flexfloat.math.rst
@@ -1,0 +1,6 @@
+﻿flexfloat.math
+==============
+
+.. currentmodule:: flexfloat
+
+.. automodule:: math

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,148 @@
+/* Custom CSS for FlexFloat documentation */
+
+/* Enhanced code block styling */
+.highlight {
+    border-radius: 4px;
+    margin: 1em 0;
+}
+
+.highlight pre {
+    padding: 1em;
+    overflow-x: auto;
+}
+
+/* Custom admonition styling */
+.admonition {
+    border-radius: 4px;
+    padding: 12px;
+    margin: 1em 0;
+}
+
+.admonition.note {
+    border-left: 4px solid #3498db;
+    background-color: #ebf5ff;
+}
+
+.admonition.warning {
+    border-left: 4px solid #f39c12;
+    background-color: #fef9e7;
+}
+
+.admonition.tip {
+    border-left: 4px solid #27ae60;
+    background-color: #eafaf1;
+}
+
+/* Table styling improvements */
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+    white-space: normal;
+}
+
+.rst-content table.docutils thead th {
+    background-color: #f8f9fa;
+}
+
+/* Navigation improvements */
+.wy-nav-side {
+    background: #2c3e50;
+}
+
+.wy-nav-top {
+    background: #2980b9;
+}
+
+/* Search box styling */
+.wy-side-nav-search {
+    background: #2c3e50;
+}
+
+.wy-side-nav-search input[type=text] {
+    border-radius: 4px;
+}
+
+/* Logo spacing */
+.wy-side-nav-search .wy-dropdown > a img.logo,
+.wy-side-nav-search > a img.logo {
+    max-height: 50px;
+    margin: 0.85em auto;
+}
+
+/* API documentation improvements */
+.rst-content dl:not(.docutils) dt {
+    background: #f8f9fa;
+    color: #2c3e50;
+    border-top: 3px solid #3498db;
+}
+
+/* Signature improvements */
+.rst-content .viewcode-link,
+.rst-content .viewcode-back {
+    float: right;
+    font-size: 0.8em;
+}
+
+/* Method and class signature styling */
+.sig-name {
+    font-weight: bold;
+}
+
+.sig-paren {
+    color: #7f8c8d;
+}
+
+/* Footer improvements */
+.rst-footer-buttons {
+    margin-top: 2em;
+}
+
+/* Custom button styling */
+.btn-neutral {
+    background-color: #95a5a6;
+    color: white;
+}
+
+.btn-neutral:hover {
+    background-color: #7f8c8d;
+    color: white;
+}
+
+/* Copy button improvements */
+.copybtn {
+    opacity: 0.3;
+    transition: opacity 0.3s;
+}
+
+.copybtn:hover {
+    opacity: 1;
+}
+
+/* Sidebar improvements */
+.wy-menu-vertical li.toctree-l1 > a {
+    font-weight: bold;
+}
+
+.wy-menu-vertical li.toctree-l2 > a {
+    padding-left: 2.4em;
+}
+
+.wy-menu-vertical li.toctree-l3 > a {
+    padding-left: 3.6em;
+}
+
+/* GitHub edit link styling */
+.edit-github {
+    float: right;
+    margin-top: -20px;
+}
+
+.edit-github a {
+    color: #7f8c8d;
+    font-size: 0.9em;
+    text-decoration: none;
+}
+
+.edit-github a:hover {
+    color: #2c3e50;
+    text-decoration: underline;
+}

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,31 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :no-index:
+   :exclude-members: {% if objname == "FlexFloat" %}sign, exponent, fraction{% endif %}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,1 @@
+{% extends "!layout.html" %}

--- a/docs/source/api/bitarray.rst
+++ b/docs/source/api/bitarray.rst
@@ -1,0 +1,175 @@
+BitArray Module
+===============
+
+The BitArray module provides different implementations for efficient bit manipulation in FlexFloat.
+
+Base BitArray Protocol
+----------------------
+
+.. autoclass:: flexfloat.BitArray
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+Implementations
+---------------
+
+ListBoolBitArray
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: flexfloat.ListBoolBitArray
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+ListInt64BitArray
+^^^^^^^^^^^^^^^^^
+
+.. autoclass:: flexfloat.ListInt64BitArray
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+BigIntBitArray
+^^^^^^^^^^^^^^
+
+.. autoclass:: flexfloat.BigIntBitArray
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+Usage Examples
+--------------
+
+Choosing a BitArray Implementation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat, ListBoolBitArray, ListInt64BitArray, BigIntBitArray
+
+   # Use different implementations
+   FlexFloat.set_bitarray_implementation(ListBoolBitArray)
+   FlexFloat.set_bitarray_implementation(ListInt64BitArray)
+   FlexFloat.set_bitarray_implementation(BigIntBitArray)
+   
+Performance Characteristics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: BitArray Performance Comparison
+   :header-rows: 1
+   :widths: 25 25 25 25
+
+   * - Implementation
+     - Memory Usage
+     - Speed
+     - Best Use Case
+   * - ListBoolBitArray
+     - High
+     - Slow
+     - Debugging, small numbers
+   * - ListInt64BitArray
+     - Medium
+     - Fast
+     - General purpose
+   * - BigIntBitArray
+     - Low
+     - Very Fast
+     - Large numbers, production
+
+Direct BitArray Usage
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from flexfloat import ListInt64BitArray
+
+   # Create a BitArray
+   bits = ListInt64BitArray([0], length=8)  # 8-bit array
+
+   # Set individual bits
+   bits[0] = True
+   bits[7] = True
+
+   # Get bits
+   print(bits[0])  # True
+   print(bits[1])  # False
+
+   # Convert to integer
+   value = bits.to_int()
+   print(value)    # 129
+
+   # Create from integer
+   bits2 = ListInt64BitArray.from_signed_int(128, 8)
+   print(bits2.to_int())  # 255
+
+BitArray Operations
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from flexfloat import ListInt64BitArray
+
+   # Create BitArrays
+   a = ListInt64BitArray.from_signed_int(12, 4)  # 1100
+   b = ListInt64BitArray.from_signed_int(10, 4)  # 1010
+
+   # Bitwise operations (if implemented)
+   and_result = a & b    # 1000 = 8
+   or_result = a | b     # 1110 = 14
+   xor_result = a ^ b    # 0110 = 6
+   not_result = ~a       # 0011 = 3
+
+Extending BitArrays
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from flexfloat import ListInt64BitArray
+
+   # Start with small BitArray
+   bits = ListInt64BitArray.from_signed_int(5, 4)  # 0101
+   print(len(bits))  # 4
+
+   # Extend it (if implemented)
+   extended = bits.extend(8)
+   print(len(extended))  # 8
+   print(extended.to_int())  # Still 5, but with more bits
+
+Custom BitArray Implementation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can create your own BitArray implementation by following the protocol:
+
+.. code-block:: python
+
+   from flexfloat.bitarray import BitArray
+   from typing import Iterator
+
+   class CustomBitArray(BitArray):
+       def __init__(self, length: int):
+           self._data = [False] * length
+       def __len__(self) -> int:
+           return len(self._data)
+       def __getitem__(self, index: int) -> bool:
+           return self._data[index]
+       def __setitem__(self, index: int, value: bool) -> None:
+           self._data[index] = value
+       def __iter__(self) -> Iterator[bool]:
+           return iter(self._data)
+       def to_int(self) -> int:
+           result = 0
+           for i, bit in enumerate(self._data):
+               if bit:
+                   result |= (1 << i)
+           return result
+       @classmethod
+       def from_signed_int(cls, value: int, length: int) -> 'CustomBitArray':
+           bits = cls(length)
+           for i in range(length):
+               bits[i] = bool(value & (1 << i))
+           return bits

--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -1,0 +1,131 @@
+Core API
+========
+
+This section documents the core FlexFloat class and its methods.
+
+FlexFloat Class
+---------------
+
+.. autoclass:: flexfloat.FlexFloat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__, __add__, __sub__, __mul__, __truediv__, __pow__, __eq__, __ne__, __lt__, __le__, __gt__, __ge__, __str__, __repr__, __float__, __int__, __bool__, pretty, abs, copy
+   :no-index:
+
+Class Methods
+~~~~~~~~~~~~~
+
+.. automethod:: flexfloat.FlexFloat.from_float
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.nan
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.infinity
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.zero
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.set_bitarray_implementation
+   :no-index:
+
+Instance Methods
+~~~~~~~~~~~~~~~~
+
+Type Checking
+^^^^^^^^^^^^^
+
+.. automethod:: flexfloat.FlexFloat.is_zero
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.is_infinity
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.is_nan
+   :no-index:
+
+Conversion Methods
+^^^^^^^^^^^^^^^^^^
+
+.. automethod:: flexfloat.FlexFloat.to_float
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.copy
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.abs
+   :no-index:
+.. automethod:: flexfloat.FlexFloat.pretty
+   :no-index:
+
+Examples
+--------
+
+Basic Usage
+~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Create FlexFloat numbers
+   x = FlexFloat.from_float(1.5)
+   y = FlexFloat.from_float(2.5)
+
+   # Arithmetic operations
+   sum_result = x + y
+   print(sum_result)  # 4.00000e+00
+   product = x * y
+   print(product)  # 3.75000e+00
+   quotient = x / y
+   print(quotient)  # 6.00000e-01
+   power = x ** 2
+   print(power)  # 2.25000e+00
+
+Special Values
+~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Create special values
+   inf = FlexFloat.infinity()
+   nan = FlexFloat.nan()
+   zero = FlexFloat.zero()
+
+   # Check types
+   print(inf.is_infinity())    # True
+   print(nan.is_nan())         # True
+   print(zero.is_zero())       # True
+   print(inf)                  # inf
+   print(nan)                  # nan
+   print(zero)                 # 0.0
+
+Large Numbers
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Work with numbers beyond float range
+   large = FlexFloat.from_float(10) ** 400
+   very_large = large * FlexFloat.from_float(2)
+
+   print(very_large)  # 5.67344e+921
+
+Type Conversions
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # From various types
+   from_int = FlexFloat.from_float(42)
+   from_float = FlexFloat.from_float(3.14159)
+
+   # To various types
+   as_float = from_float.to_float()
+
+   # Copy and abs
+   copy = from_float.copy()
+   absolute = from_float.abs()
+
+   # Pretty string
+   print(from_float.pretty())  # FlexFloat(exponent=1, fraction=2570632149304942)

--- a/docs/source/api/math.rst
+++ b/docs/source/api/math.rst
@@ -1,0 +1,136 @@
+Math Module
+===========
+
+The FlexFloat math module provides mathematical functions that work with FlexFloat numbers.
+
+.. automodule:: flexfloat.math
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Logarithmic Functions
+=====================
+
+.. autofunction:: flexfloat.math.log
+   :no-index:
+.. autofunction:: flexfloat.math.log2
+   :no-index:
+.. autofunction:: flexfloat.math.log10
+   :no-index:
+
+Exponential Functions
+=====================
+
+.. autofunction:: flexfloat.math.exp
+   :no-index:
+
+Power Functions
+===============
+
+.. autofunction:: flexfloat.math.sqrt
+   :no-index:
+.. autofunction:: flexfloat.math.pow
+   :no-index:
+
+Examples
+--------
+
+Logarithmic Operations
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   from flexfloat import math as ffmath
+
+   x = FlexFloat.from_float(100.0)
+
+   # Natural logarithm
+   ln_x = ffmath.log(x)      # Natural log (base e)
+   print(ln_x)
+
+   # Base-2 logarithm  
+   log2_x = ffmath.log2(x)
+   print(log2_x)
+
+   # Base-10 logarithm
+   log10_x = ffmath.log10(x)
+   print(log10_x)
+
+Exponential Operations
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   from flexfloat import math as ffmath
+
+   x = FlexFloat.from_float(2.0)
+
+   # Natural exponential
+   exp_x = ffmath.exp(x)
+   print(exp_x)
+
+Power Operations
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   from flexfloat import math as ffmath
+
+   x = FlexFloat.from_float(16.0)
+   y = FlexFloat.from_float(3.0)
+
+   # Square root
+   sqrt_x = ffmath.sqrt(x)
+   print(sqrt_x)
+
+   # General power
+   pow_xy = ffmath.pow(x, y)
+   print(pow_xy)
+
+Working with Large Numbers
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   from flexfloat import math as ffmath
+
+   # Large number operations
+   large = FlexFloat.from_float(10) ** 100
+   
+   # Logarithm of large number
+   log_large = ffmath.log10(large)
+   print(log_large)
+
+   # Square root of large number
+   sqrt_large = ffmath.sqrt(large)
+   print(sqrt_large)
+
+Special Cases
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   from flexfloat import math as ffmath
+
+   zero = FlexFloat.zero()
+   one = FlexFloat.from_float(1.0)
+   inf = FlexFloat.infinity()
+
+   # Logarithm special cases
+   print(ffmath.log(one))    # 0.0
+   print(ffmath.log(inf))    # infinity
+   # ffmath.log(zero)        # would be negative infinity or error
+
+   # Exponential special cases
+   print(ffmath.exp(zero))   # 1.0
+   print(ffmath.exp(inf))    # infinity
+
+   # Power special cases
+   print(ffmath.sqrt(zero))  # 0.0
+   print(ffmath.sqrt(one))   # 1.0
+   print(ffmath.pow(zero, one))  # 0.0

--- a/docs/source/api/types.rst
+++ b/docs/source/api/types.rst
@@ -1,0 +1,14 @@
+Types Module
+============
+
+This module contains type definitions and protocols used throughout FlexFloat.
+
+.. automodule:: flexfloat.types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Type Aliases
+============
+
+.. autodata:: flexfloat.types.Number

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,220 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+import warnings
+from pathlib import Path
+
+# -- Path setup --------------------------------------------------------------
+
+# Add the project root directory to the Python path so we can import the package
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import the package to get version info
+import flexfloat
+
+# Set up logging filter for Sphinx warnings
+import logging
+
+
+def setup(app):
+    """Setup function to configure Sphinx app."""
+
+    # Create a custom logging filter
+    class DuplicateObjectFilter(logging.Filter):
+        def filter(self, record):
+            # Filter out duplicate object description warnings
+            return not (
+                "duplicate object description" in record.getMessage()
+                and any(
+                    prop in record.getMessage()
+                    for prop in ["sign", "exponent", "fraction"]
+                )
+            )
+
+    # Apply the filter to the sphinx logger
+    sphinx_logger = logging.getLogger("sphinx")
+    sphinx_logger.addFilter(DuplicateObjectFilter())
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
+
+# -- Project information -----------------------------------------------------
+
+project = "FlexFloat"
+copyright = "2025, Ferran Sanchez Llado"
+author = "Ferran Sanchez Llado"
+
+# The full version, including alpha/beta/rc tags
+release = flexfloat.__version__
+version = ".".join(release.split(".")[:2])  # Short version (e.g., "0.3")
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autodoc",  # Automatic documentation from docstrings
+    "sphinx.ext.autosummary",  # Generate autodoc summaries
+    "sphinx.ext.viewcode",  # Add links to highlighted source code
+    "sphinx.ext.napoleon",  # Support for NumPy and Google style docstrings
+    "sphinx.ext.intersphinx",  # Link to other project's documentation
+    "sphinx.ext.mathjax",  # Render math via JavaScript
+    "sphinx.ext.githubpages",  # Publish HTML docs in GitHub pages
+    "sphinx_rtd_theme",  # Read the Docs theme
+    "sphinx_copybutton",  # Add copy button to code blocks
+    "myst_parser",  # Markdown support
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = []
+
+# Suppress specific warnings
+suppress_warnings = [
+    "autodoc",  # Suppress all autodoc warnings including duplicate object warnings
+    "app.add_node",  # Suppress add_node warnings
+    "app.add_directive",  # Suppress add_directive warnings
+    "ref.python",  # Suppress Python reference warnings
+]
+
+# The master toctree document.
+master_doc = "index"
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.
+html_theme = "sphinx_rtd_theme"
+
+# Theme options are theme-specific and customize the look and feel of a theme
+html_theme_options = {
+    "analytics_id": "",
+    "analytics_anonymize_ip": False,
+    "logo_only": False,
+    "prev_next_buttons_location": "bottom",
+    "style_external_links": False,
+    "vcs_pageview_mode": "",
+    "style_nav_header_background": "#2980b9",
+    # Toc options
+    "collapse_navigation": True,
+    "sticky_navigation": True,
+    "navigation_depth": 4,
+    "includehidden": True,
+    "titles_only": False,
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+# Custom CSS files
+html_css_files = [
+    "custom.css",
+]
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = "sphinx"
+
+# -- Extension configuration -------------------------------------------------
+
+# napoleon configuration
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = True
+napoleon_attr_annotations = True
+
+# autodoc configuration
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
+}
+
+# Enable type hint cross-referencing
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
+autodoc_type_aliases = {
+    "BitArray": "flexfloat.BitArray",
+}
+
+# autosummary configuration
+autosummary_generate = True
+autosummary_imported_members = True
+
+# intersphinx configuration
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+}
+
+# copybutton configuration
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+
+# MyST parser configuration
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "substitution",
+    "tasklist",
+]
+
+# -- HTML context configuration ---------------------------------------------
+
+# Custom HTML context
+html_context = {
+    "READTHEDOCS": os.environ.get("READTHEDOCS", False),
+    "github_user": "ferranSanchezLlado",
+    "github_repo": "flexfloat-py",
+    "github_version": "main",
+    "conf_py_path": "/docs/source/",
+}
+
+# HTML title
+html_title = f"{project} v{release}"
+
+# Favicon (uncomment when you have a favicon.ico file)
+# html_favicon = '_static/favicon.ico'
+
+# Logo (uncomment when you have a logo.png file)
+# html_logo = '_static/logo.png'
+
+# Show source links
+html_show_sourcelink = True
+
+# Add edit on GitHub links
+html_context.update(
+    {
+        "display_github": True,
+        "github_user": "ferranSanchezLlado",
+        "github_repo": "flexfloat-py",
+        "github_version": "main",
+        "conf_py_path": "/docs/source/",
+    }
+)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,11 +14,11 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-# Import the package to get version info
-import flexfloat
-
 # Set up logging filter for Sphinx warnings
 import logging
+
+# Import the package to get version info
+import flexfloat
 
 
 def setup(app):

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -1,0 +1,8 @@
+Examples
+========
+
+This section provides practical examples of using FlexFloat in various scenarios.
+
+.. note::
+   More detailed examples will be added in future versions. For now, see the
+   :doc:`../quickstart` guide for basic usage examples.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,148 @@
+FlexFloat Documentation
+=======================
+
+.. image:: https://img.shields.io/badge/python-3.11+-blue.svg
+   :target: https://www.python.org/downloads/
+   :alt: Python 3.11+
+
+.. image:: https://img.shields.io/badge/License-MIT-yellow.svg
+   :target: https://opensource.org/licenses/MIT
+   :alt: License: MIT
+
+.. image:: https://badge.fury.io/py/flexfloat.svg
+   :target: https://badge.fury.io/py/flexfloat
+   :alt: PyPI version
+
+Welcome to FlexFloat, a high-precision Python library for arbitrary precision floating-point arithmetic with **growable exponents** and **fixed-size fractions**.
+
+FlexFloat extends IEEE 754 double-precision format to handle numbers beyond the standard range while maintaining computational efficiency and precision consistency.
+
+✨ Key Features
+----------------
+
+- **🔢 Growable Exponents**: Dynamically expand exponent size to handle extremely large (>10^308) or small (<10^-308) numbers
+- **🎯 Fixed-Size Fractions**: Maintain IEEE 754-compatible 52-bit fraction precision for consistent accuracy
+- **⚡ Full Arithmetic Support**: Addition, subtraction, multiplication, division, and power operations
+- **🔧 Multiple BitArray Backends**: Choose between bool-list, int64-list, and big-integer implementations for optimal performance
+- **🌟 Special Value Handling**: Complete support for NaN, ±infinity, and zero values
+- **🛡️ Overflow Protection**: Automatic exponent growth prevents overflow/underflow errors
+- **📊 IEEE 754 Baseline**: Fully compatible with standard double-precision format as the starting point
+
+🚀 Quick Start
+---------------
+
+Installation
+~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   pip install flexfloat
+
+Basic Usage
+~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Create a FlexFloat number
+   x = FlexFloat(1.5)
+   y = FlexFloat(2.5)
+
+   # Perform arithmetic operations
+   result = x + y
+   print(result)  # FlexFloat(4.0)
+
+   # Handle very large numbers
+   large_num = FlexFloat(10) ** 400
+   print(large_num)  # Handles numbers beyond standard float range
+
+📚 Table of Contents
+---------------------
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   installation
+   quickstart
+   user_guide/index
+   examples/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api/core
+   api/bitarray
+   api/types
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Math API
+
+   api/math
+
+📖 API Documentation
+---------------------
+
+Core Classes
+~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: class.rst
+
+   flexfloat.FlexFloat
+
+BitArray Implementations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: class.rst
+
+   flexfloat.BitArray
+   flexfloat.ListBoolBitArray
+   flexfloat.ListInt64BitArray
+   flexfloat.BigIntBitArray
+
+Math Functions
+~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: module.rst
+
+   flexfloat.math
+
+🔗 Indices and Tables
+----------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+🤝 Contributing
+----------------
+
+We welcome contributions! Please see our `Contributing Guide <contributing.html>`_ for details on how to get started.
+
+📄 License
+-----------
+
+This project is licensed under the MIT License - see the `License <license.html>`_ file for details.
+
+💬 Support
+-----------
+
+If you encounter any issues or have questions, please:
+
+1. Check the `documentation <https://flexfloat-py.readthedocs.io/>`_
+2. Search existing `GitHub issues <https://github.com/ferranSanchezLlado/flexfloat-py/issues>`_
+3. Create a new issue if needed
+
+📊 Version Information
+-----------------------
+
+This documentation is for FlexFloat version |version|.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,113 @@
+Installation
+============
+
+Requirements
+------------
+
+FlexFloat requires Python 3.11 or higher.
+
+Installing from PyPI
+--------------------
+
+The easiest way to install FlexFloat is using pip:
+
+.. code-block:: bash
+
+   pip install flexfloat
+
+Installing from Source
+----------------------
+
+To install from source, first clone the repository:
+
+.. code-block:: bash
+
+   git clone https://github.com/ferranSanchezLlado/flexfloat-py.git
+   cd flexfloat-py
+
+Then install the package:
+
+.. code-block:: bash
+
+   pip install .
+
+Development Installation
+------------------------
+
+For development, you can install the package in editable mode with development dependencies:
+
+.. code-block:: bash
+
+   git clone https://github.com/ferranSanchezLlado/flexfloat-py.git
+   cd flexfloat-py
+   pip install -e ".[dev]"
+
+This will install the package in editable mode along with all development dependencies including:
+
+- pytest (testing framework)
+- black (code formatting)
+- mypy (type checking)
+- pylint (linting)
+- sphinx (documentation)
+
+Verifying Installation
+----------------------
+
+To verify that FlexFloat is installed correctly, you can run:
+
+.. code-block:: python
+
+   import flexfloat
+   print(flexfloat.__author__)  # Ferran Sanchez Llado
+
+Or test basic functionality:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   
+   x = FlexFloat(1.5)
+   y = FlexFloat(2.5)
+   result = x + y
+   print(result)  # 4.00000e+00
+
+Troubleshooting
+---------------
+
+Common Issues
+~~~~~~~~~~~~~
+
+**Import Error**
+   If you get an import error, make sure you have Python 3.11 or higher:
+   
+   .. code-block:: bash
+   
+      python --version
+
+**Permission Error**
+   If you get permission errors during installation, try using a virtual environment:
+   
+   .. code-block:: bash
+   
+      python -m venv flexfloat-env
+      source flexfloat-env/bin/activate  # On Windows: flexfloat-env\Scripts\activate
+      pip install flexfloat
+
+Virtual Environment
+~~~~~~~~~~~~~~~~~~~
+
+We recommend using a virtual environment to avoid conflicts with other packages:
+
+.. code-block:: bash
+
+   # Create virtual environment
+   python -m venv flexfloat-env
+   
+   # Activate virtual environment
+   # On Windows:
+   flexfloat-env\Scripts\activate
+   # On macOS/Linux:
+   source flexfloat-env/bin/activate
+   
+   # Install FlexFloat
+   pip install flexfloat

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,0 +1,161 @@
+Quick Start Guide
+=================
+
+This guide will help you get started with FlexFloat quickly.
+
+Basic Usage
+-----------
+
+Creating FlexFloat Numbers
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Create from float or int
+   x = FlexFloat.from_float(42)
+   y = FlexFloat.from_float(3.14159)
+   # Create with custom precision (default is 11 exponent bits, 52 fraction bits)
+   # Not directly supported in constructor, but can be set via bitarray implementation
+   print(x)  # 4.20000e+01
+   print(y)  # 3.14159e+00
+
+Arithmetic Operations
+~~~~~~~~~~~~~~~~~~~~~
+
+FlexFloat supports all basic arithmetic operations:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   a = FlexFloat.from_float(10.5)
+   b = FlexFloat.from_float(2.5)
+
+   # Addition
+   result_add = a + b
+   print(result_add)  # 1.30000e+01
+
+   # Subtraction
+   result_sub = a - b
+   print(result_sub)  # 8.00000e+00
+
+   # Multiplication
+   result_mul = a * b
+   print(result_mul)  # 2.62500e+01
+
+   # Division
+   result_div = a / b
+   print(result_div)  # 4.20000e+00
+
+   # Power
+   result_pow = a ** 2
+   print(result_pow)  # 1.10250e+02
+
+Working with Large Numbers
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+FlexFloat can handle numbers beyond the range of standard floats:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Create a very large number
+   large = FlexFloat.from_float(10) ** 400
+   print(large)  # 2.83672e+921
+
+   # Arithmetic with large numbers
+   larger = large * FlexFloat.from_float(2)
+   print(larger)  # 5.67344e+921
+
+   # Very small numbers
+   small = FlexFloat.from_float(1) / (FlexFloat.from_float(10) ** 400)
+   print(small)  # 3.52520e-922
+
+Math Functions
+~~~~~~~~~~~~~~
+
+FlexFloat includes a math module with common mathematical functions:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+   from flexfloat import math as ffmath
+
+   x = FlexFloat.from_float(2.0)
+
+   # Logarithms
+   log_result = ffmath.log(x)
+   log10_result = ffmath.log10(x)
+   log2_result = ffmath.log2(x)
+
+   # Exponentials
+   exp_result = ffmath.exp(x)
+
+   # Power functions
+   sqrt_result = ffmath.sqrt(x)
+   pow_result = ffmath.pow(x, FlexFloat.from_float(3))
+
+Special Values
+~~~~~~~~~~~~~~
+
+FlexFloat supports IEEE 754 special values:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Infinity
+   pos_inf = FlexFloat.infinity()
+   print(pos_inf.is_infinity())  # True
+   neg_inf = FlexFloat.infinity(sign=True)
+
+   # NaN (Not a Number)
+   nan = FlexFloat.nan()
+   print(nan.is_nan())  # True
+
+   # Zero
+   zero = FlexFloat.zero()
+   print(zero.is_zero())  # True
+
+BitArray Backends
+~~~~~~~~~~~~~~~~~
+
+FlexFloat supports different BitArray implementations for optimal performance:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat, ListBoolBitArray, ListInt64BitArray, BigIntBitArray
+
+   # Set the BitArray implementation globally
+   FlexFloat.set_bitarray_implementation(ListBoolBitArray)
+   x1 = FlexFloat.from_float(1.5)
+   print(x1)  # 1.50000e+00
+   FlexFloat.set_bitarray_implementation(ListInt64BitArray)
+   x2 = FlexFloat.from_float(1.5)
+   print(x2)  # 1.50000e+00
+   FlexFloat.set_bitarray_implementation(BigIntBitArray)
+   x3 = FlexFloat.from_float(1.5)
+   print(x3)  # 1.50000e+00
+
+   # All produce the same result but with different internal representations
+   print(x1.to_float() == x2.to_float() == x3.to_float())  # True
+
+String Representation
+~~~~~~~~~~~~~~~~~~~~~
+
+FlexFloat provides multiple string representations:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   x = FlexFloat.from_float(123.456)
+
+   # Default representation
+   print(str(x))  # 1.23456e+02
+
+   # Detailed representation
+   print(repr(x)) # FlexFloat(sign=False, exponent=10000000101, fraction=1110110111010010111100011010100111111011111001110111)

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -1,0 +1,221 @@
+Core Concepts
+=============
+
+Understanding FlexFloat's Architecture
+--------------------------------------
+
+FlexFloat is designed around the concept of **growable exponents** and **fixed-size fractions**. This section explains the fundamental concepts that make FlexFloat unique.
+
+IEEE 754 Foundation
+~~~~~~~~~~~~~~~~~~~
+
+FlexFloat builds upon the IEEE 754 double-precision floating-point standard:
+
+- **Sign bit**: 1 bit indicating positive (0) or negative (1)
+- **Exponent**: Variable length (starts at 11 bits for double precision)
+- **Fraction**: Fixed at 52 bits (mantissa without implicit leading 1)
+
+Traditional IEEE 754 Limitations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Standard double-precision floats have limitations:
+
+- **Range**: Approximately ±1.8 × 10^308
+- **Overflow**: Numbers beyond this range become infinity
+- **Underflow**: Very small numbers become zero
+
+FlexFloat's Innovation
+~~~~~~~~~~~~~~~~~~~~~~
+
+FlexFloat overcomes these limitations through:
+
+1. **Growable Exponents**: When a number exceeds the current exponent range, FlexFloat automatically increases the exponent bit length
+2. **Fixed Precision**: The fraction remains at 52 bits, maintaining consistent precision
+3. **Seamless Transition**: Operations seamlessly handle the transition between different exponent sizes
+
+Number Representation
+---------------------
+
+FlexFloat Structure
+~~~~~~~~~~~~~~~~~~~
+
+A FlexFloat number consists of:
+
+.. code-block:: python
+
+   FlexFloat(
+       sign=False,           # Boolean: False=positive, True=negative
+       exponent=BitArray,    # Variable-length exponent
+       fraction=BitArray     # Fixed 52-bit fraction
+   )
+
+Example representations:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Standard double precision equivalent
+   x = FlexFloat.from_float(1.5)
+   print(f"Sign: {x.sign}")  # Sign: False
+   print(f"Exponent length: {len(x.exponent)} bits")  # Exponent length: 11 bits
+   print(f"Fraction length: {len(x.fraction)} bits")  # Fraction length: 52 bits
+
+Exponent Growth
+~~~~~~~~~~~~~~~
+
+When an operation would cause overflow, FlexFloat grows the exponent:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Start with standard precision
+   x = FlexFloat.from_float(10.0)
+   print(f"Initial exponent length: {len(x.exponent)} bits")  # Initial exponent length: 11 bits
+
+   # Perform operation that would overflow standard float
+   large = x ** 400
+   print(f"After large operation: {len(large.exponent)} bits")  # After large operation: 14 bits
+
+Special Values
+--------------
+
+FlexFloat supports all IEEE 754 special values with extended range:
+
+Infinity
+~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Positive and negative infinity
+   pos_inf = FlexFloat.infinity()
+   neg_inf = FlexFloat.infinity(sign=True)
+
+   # Infinity arithmetic
+   result = pos_inf + FlexFloat.from_float(1000)  # Still positive infinity
+   result = pos_inf * neg_inf                     # Negative infinity
+
+NaN (Not a Number)
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Create NaN
+   nan = FlexFloat.nan()
+
+   # NaN propagation
+   result = nan + FlexFloat.from_float(42)        # Result is NaN
+   result = FlexFloat.zero() / FlexFloat.zero()   # Division by zero gives NaN
+
+Zero Values
+~~~~~~~~~~~
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Zero value
+   zero = FlexFloat.zero()
+
+   # Zero arithmetic
+   result = zero + zero        # Zero
+   result = FlexFloat.from_float(1) * zero    # Zero
+
+Precision and Accuracy
+----------------------
+
+Mantissa Precision
+~~~~~~~~~~~~~~~~~~
+
+FlexFloat maintains 52-bit fraction precision regardless of exponent size:
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # All these maintain the same fractional precision
+   small = FlexFloat.from_float(1.23456789012345)
+   medium = FlexFloat.from_float(1.23456789012345e100)
+   large = FlexFloat.from_float(1.23456789012345e1000)
+
+Rounding Behavior
+~~~~~~~~~~~~~~~~~
+
+FlexFloat follows IEEE 754 rounding rules:
+
+- **Round to nearest, ties to even** (default)
+- Consistent rounding across all operations
+- Preserves mathematical properties
+
+.. code-block:: python
+
+   from flexfloat import FlexFloat
+
+   # Rounding examples
+   x = FlexFloat.from_float(1) / FlexFloat.from_float(3)     # 0.333...
+   y = x * FlexFloat.from_float(3)                # Close to 1.0, with rounding
+
+Comparison with Standard Floats
+-------------------------------
+
+Range Comparison
+~~~~~~~~~~~~~~~~
+
+.. list-table:: Range Comparison
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Type
+     - Minimum Magnitude
+     - Maximum Magnitude
+   * - IEEE 754 Double
+     - ~2.2 × 10^-308
+     - ~1.8 × 10^308
+   * - FlexFloat
+     - Limited by memory
+     - Limited by memory
+
+Performance Considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Standard range**: FlexFloat performs similarly to double precision
+- **Extended range**: Some overhead due to dynamic exponent management
+- **Memory usage**: Scales with exponent size
+
+Use Cases
+---------
+
+FlexFloat is ideal for:
+
+Scientific Computing
+~~~~~~~~~~~~~~~~~~~~
+
+- Astronomical calculations (very large distances)
+- Quantum mechanics (very small scales)
+- Numerical analysis requiring extended range
+
+Financial Modeling
+~~~~~~~~~~~~~~~~~~
+
+- Long-term compound interest calculations
+- Risk modeling with extreme scenarios
+- High-precision currency conversions
+
+Engineering Applications
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Simulations requiring extended precision
+- Control systems with wide dynamic ranges
+- Signal processing with extreme values
+
+Mathematical Research
+~~~~~~~~~~~~~~~~~~~~~
+
+- Number theory computations
+- Iterative algorithms prone to overflow
+- Exploration of mathematical constants

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -1,0 +1,13 @@
+User Guide
+==========
+
+This comprehensive user guide covers all aspects of using FlexFloat effectively.
+
+.. toctree::
+   :maxdepth: 2
+
+   concepts
+
+.. note::
+   Additional user guide sections (arithmetic, precision, bitarray_backends, 
+   performance, advanced_usage) will be added in future versions.

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -25,7 +25,7 @@ from .bitarray import (
 )
 from .core import FlexFloat
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "Ferran Sanchez Llado"
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flexfloat"
-version = "0.3.1"
+version = "0.3.2"
 description = "A library for arbitrary precision floating point arithmetic"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,14 @@ dev = [
     "check-manifest>=0.49",
     "PyYAML>=6.0",
 ]
+docs = [
+    "sphinx>=7.0",
+    "sphinx-rtd-theme>=2.0",
+    "sphinx-copybutton>=0.5",
+    "myst-parser>=2.0",
+    "sphinx-autobuild>=2021.3.14",
+    "requests>=2.25.0",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
- Add full Sphinx documentation structure under docs/ with user guide, API reference, quickstart, and examples.
- Add custom theme, CSS, and templates for improved documentation appearance.
- Add Makefile and make.bat for building docs on all platforms.
- Add GitHub Actions workflow for building and deploying documentation to GitHub Pages.
- Update pyproject.toml to include documentation dependencies.
- Add detailed API docs for core, bitarray, math, and types modules.
- Add user guide covering concepts, installation, and usage.