### PR TITLE
fix: allow release workflow after skip-ci version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = False
 tag = False
 allow_dirty = True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FlexFloat 1.0.1
+# FlexFloat
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/flexfloat/__init__.py
+++ b/flexfloat/__init__.py
@@ -38,7 +38,7 @@ from .bitarray import (
 )
 from .core import FlexFloat
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Ferran Sanchez Llado"
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flexfloat"
-version = "1.1.0"
+version = "1.1.1"
 description = "A high-precision Python library for arbitrary precision floating-point arithmetic with growable exponents and fractions"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- switch the release workflow from `pull_request` to `pull_request_target` for closed PR events
- avoid `[skip ci]` version bump commits suppressing automatic releases
- keep the existing merged + `release` label guard before publishing

## Verification
- git diff --check
- parsed all workflow YAML files with PyYAML